### PR TITLE
DISCOVERYACCESS-3983: display info button as inline-block because at …

### DIFF
--- a/app/assets/stylesheets/cornell/_item-record.scss
+++ b/app/assets/stylesheets/cornell/_item-record.scss
@@ -238,6 +238,8 @@ padding-left: 6em;
 	}
 	.info-button, .info-button:hover, .info-button:active, .info-button:focus {
 		border-bottom: 0;
+		// DISCOVERYACCESS-3983 - sometimes the info button breaks onto two lines in Firefox
+		display: inline-block;
 	}
 }
 

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -17,7 +17,7 @@
           <% else search = heading['search1']  %>
           <% end %>
           <%# show heading popover for everything bigger than smartphone %>
- <a href='#' role="button" tabindex = "0" data-poload='/browse/info?authq=<%=  search %>&amp;browse_type=Author&amp;headingtype=<%=  type %>' id="info" class="info-button hidden-xs"><span class="label label-info">
+          <a href='#' role="button" tabindex = "0" data-poload='/browse/info?authq=<%=  search %>&amp;browse_type=Author&amp;headingtype=<%=  type %>' id="info" class="info-button hidden-xs"><span class="label label-info">
             Info
           </span>
           </a>


### PR DESCRIPTION
…certain widths it wraps onto two lines in firefox