### PR TITLE
Discoveryaccess 4129

### DIFF
--- a/app/controllers/book_bags_controller.rb
+++ b/app/controllers/book_bags_controller.rb
@@ -127,9 +127,13 @@ class BookBagsController < CatalogController
     else
       flash[:error] = I18n.t('blacklight.bookmarks.clear.failure')
     end
-    redirect_to (root_url() + "bookmarks/clear")
+    current_or_guest_user.bookmarks.clear
+    redirect_to :action => "index"
   end
 
+
+
+   
   def action_documents
     options =   {:per_page => 1000,:rows => 1000}
     @bms =@bb.index

--- a/app/controllers/book_bags_controller.rb
+++ b/app/controllers/book_bags_controller.rb
@@ -123,11 +123,13 @@ class BookBagsController < CatalogController
     success = @bb.clear
     Rails.logger.info("es289_debug #{__FILE__} #{__LINE__} #{__method__} @bb = #{@bb.inspect}")
     if success
+      if current_or_guest_user.bookmarks.count > 0
+        current_or_guest_user.bookmarks.clear
+      end
       flash[:notice] = I18n.t('blacklight.bookmarks.clear.success')
     else
       flash[:error] = I18n.t('blacklight.bookmarks.clear.failure')
     end
-    current_or_guest_user.bookmarks.clear
     redirect_to :action => "index"
   end
 


### PR DESCRIPTION
Completely clear bookmarks when clearing book_bags. Find current bookmarks in addbookmarks rather than passing them in form URL