### PR TITLE
Add the ability to temporarily disable Aeon requests (DISCOVERYACCESS-4094)

### DIFF
--- a/app/views/catalog/_request_buttons.html.erb
+++ b/app/views/catalog/_request_buttons.html.erb
@@ -6,7 +6,9 @@
 <div class="item-requests">
   <% counter = params[:counter] || session[:search][:counter] %>
   <% if (not_spif > 0)    %>
-    <% if counter.blank? %>
+    <% if group == 'Rare' && ENV['DISABLE_AEON'] == 'true' %>
+      <%= 'Reading Room delivery and scans of these materials are temporarily unavailable.' %>
+    <% elsif counter.blank? %>
       <%= link_to "Request item#{reading}", request_context_path, { :title => 'Request', :class => 'btn btn-danger', :id => 'id_request' }  %>
       <%= link_to "Request item for scanning", request_scan_path, { :title => 'Request', :class => 'btn btn-danger', :id => 'id_request' } unless reading.empty?   %>
     <% else %>


### PR DESCRIPTION
If a line is added to the .env file stating DISABLE_AEON='true'
then the Aeon delivery and scan buttons will not appear on the catalog
view page. Instead, users will see a note stating that those functions
are temporarily unavailable.