### PR TITLE
Change Worldcat URL and search strings for switch to Worldcat Discove…

### DIFF
--- a/app/views/catalog/_expand_advanced_search.html.erb
+++ b/app/views/catalog/_expand_advanced_search.html.erb
@@ -5,7 +5,7 @@
 		</div>
 		<div class="panel-body">
 			<ul class="fa-ul">
-			    <li><i class="fa fa-arrow-right" aria-hidden="true" alt=""></i><a href="http://cornell.worldcat.org/" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'WCL']);">Search Libraries Worldwide</a></li>
+			    <li><i class="fa fa-arrow-right" aria-hidden="true" alt=""></i><a href="<%= ENV['WORLDCAT_URL'] %>" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'WCL']);">Search Libraries Worldwide</a></li>
 			    <li><i class="fa fa-arrow-right" aria-hidden="true" alt=""></i><a href="http://cornell.summon.serialssolutions.com/" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'Summon']);">Search Articles &amp; Full Text</a></li>
 			    <li><i class="fa fa-arrow-right" aria-hidden="true" alt=""></i><a href="http://www.library.cornell.edu/services/request/recommend" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'recommendpurchase']);">Recommend a Purchase</a></li>
 			</ul>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -14,7 +14,7 @@
                         <li>Or <a href="http://www.library.cornell.edu/feedback">send us comments or suggestions</a> that may help us improve the Catalog.</li>
                     </ul>
 
-                    <p>To search beyond Cornell holdings, follow the “Libraries Worldwide” link on the Catalog search results page, or use <a href="http://cornell.worldcat.org/">WorldCat Local</a>.</p>
+                    <p>To search beyond Cornell holdings, follow the “Libraries Worldwide” link on the Catalog search results page, or use <a href="<%= ENV['WORLDCAT_URL'] %>">WorldCat</a>.</p>
                 </div>
             </div>
 

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -34,7 +34,7 @@
           <%if params[:q_row].nil?  && params[:click_to_search].nil? && params[:f].nil? %>
             <a href="<%= @expanded_results['worldcat'][:url] %>">
           <% else %>
-            <a href="http://cornell.worldcat.org">
+            <a href="<%= ENV['WORLDCAT_URL'] %>">
           <%end%>
           Libraries Worldwide</a> or <a href="https://www.library.cornell.edu/services/request/recommend"> recommend a purchase</a>.</p>
         <%else%>

--- a/app/views/catalog/oclc_request.html.erb
+++ b/app/views/catalog/oclc_request.html.erb
@@ -35,7 +35,7 @@
           <%if params[:q_row].nil?  && params[:click_to_search].nil? && params[:f].nil? %>
             <a href="<%= @expanded_results['worldcat'][:url] %>">
           <% else %>
-            <a href="http://cornell.worldcat.org">
+            <a href="<%= ENV['WORLDCAT_URL'] %>">
           <%end%>
           Libraries Worldwide</a> or <a href="https://www.library.cornell.edu/services/request/recommend"> recommend a purchase</a>.</p>
         <%else%>

--- a/app/views/single_search/index.html.erb
+++ b/app/views/single_search/index.html.erb
@@ -41,7 +41,7 @@
       <% query = query.gsub('&', '%26') %>
       <p class="no-results">
         Your search returned 0 results. Try searching
-        <%= link_to 'Libraries Worldwide', "http://cornell.worldcat.org/search?q=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" %>
+        <%= link_to 'Libraries Worldwide', ENV['WORLDCAT_URL'] + "/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" %>
         or
         <%= link_to 'recommend a purchase.', "http://www.library.cornell.edu/services/request/recommend" %>
       </p>
@@ -76,7 +76,7 @@
                       </li>
                       <li>
                         <i class="fa fa-arrow-right"></i>
-                        <%= link_to "http://cornell.worldcat.org/search?q=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" do %>
+                        <%= link_to ENV['WORLDCAT_URL'] + "/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" do %>
                           Request from Libraries Worldwide
                             <%= render 'single_search/wcl_results', :key => 'worldcat', :result => @wcl %>
                         <% end %>
@@ -235,7 +235,7 @@
                         No results from the
                         <%= link_to 'Catalog.', "https://newcatalog.library.cornell.edu" %>
                         Try searching
-                        <%= link_to 'Libraries Worldwide.', "http://cornell.worldcat.org/search?q=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" %>
+                        <%= link_to 'Libraries Worldwide.', ENV['WORLDCAT_URL'] + "/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" %>
                       </p>
                     </div>
                   <% end %>

--- a/app/views/single_search/index.html.erb
+++ b/app/views/single_search/index.html.erb
@@ -41,7 +41,7 @@
       <% query = query.gsub('&', '%26') %>
       <p class="no-results">
         Your search returned 0 results. Try searching
-        <%= link_to 'Libraries Worldwide', ENV['WORLDCAT_URL'] + "/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" %>
+        <%= link_to 'Libraries Worldwide', "#{ENV['WORLDCAT_URL']}/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" %>
         or
         <%= link_to 'recommend a purchase.', "http://www.library.cornell.edu/services/request/recommend" %>
       </p>
@@ -76,7 +76,7 @@
                       </li>
                       <li>
                         <i class="fa fa-arrow-right"></i>
-                        <%= link_to ENV['WORLDCAT_URL'] + "/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" do %>
+                        <%= link_to "#{ENV['WORLDCAT_URL']}/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" do %>
                           Request from Libraries Worldwide
                             <%= render 'single_search/wcl_results', :key => 'worldcat', :result => @wcl %>
                         <% end %>
@@ -235,7 +235,7 @@
                         No results from the
                         <%= link_to 'Catalog.', "https://newcatalog.library.cornell.edu" %>
                         Try searching
-                        <%= link_to 'Libraries Worldwide.', ENV['WORLDCAT_URL'] + "/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" %>
+                        <%= link_to 'Libraries Worldwide.', "#{ENV['WORLDCAT_URL']}/search?queryString=#{query}&fq=&dblist=638&qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc" %>
                       </p>
                     </div>
                   <% end %>

--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -79,8 +79,8 @@ BentoSearch.register_engine('worldcat') do |conf|
   conf.api_key = ENV['WORLDCAT_API_KEY']
   # assume all users are affiliates and have servicelevel=full access.
   conf.auth = true
-  # Link to Cornell WCL, ensure sort by "relevance only"
-  conf.link = 'http://cornell.worldcat.org/search?qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc&q='
+  # Link to Worldcat Discovery, ensure sort by "relevance only"
+  conf.link = ENV['WORLDCAT_URL'] + '/search?qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc&queryString='
 end
 
 

--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -80,7 +80,7 @@ BentoSearch.register_engine('worldcat') do |conf|
   # assume all users are affiliates and have servicelevel=full access.
   conf.auth = true
   # Link to Worldcat Discovery, ensure sort by "relevance only"
-  conf.link = ENV['WORLDCAT_URL'] + '/search?qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc&queryString='
+  conf.link = "#{ENV['WORLDCAT_URL']}/search?qt=sort&se=nodgr&sd=desc&qt=sort_nodgr_desc&queryString="
 end
 
 


### PR DESCRIPTION
…ry (DISCOVERYACCESS-4679). Note that the WORLDCAT_URL must be defined in the .env file. Currently WORLDCAT_URL=https://cornell.on.worldcat.org

