### PR TITLE
Discoveryaccess 5656b - link Articles & Text to EDS not summon

### DIFF
--- a/app/views/catalog/_expand_advanced_search.html.erb
+++ b/app/views/catalog/_expand_advanced_search.html.erb
@@ -6,9 +6,9 @@
 		<div class="card-body">
 			<ul class="fa-ul">
 			    <li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= ENV['WORLDCAT_URL'] %>" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'WCL']);">Search Libraries Worldwide</a></li>
-			    <li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="http://encompass.library.cornell.edu/cgi-bin/checkIP.cgi?access=gateway_standard&url=http://search.ebscohost.com/login.aspx?authtype=ip,guest&profile=eds&Groupid=main&custid=s9001366" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'EDS']);">Search Articles &amp; Full Text</a></li>
+			    <li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= bento_all_results_link('ebsco_ds') %>" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'EDS']);">Search Articles &amp; Full Text</a></li>
 			    <li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="http://www.library.cornell.edu/services/request/recommend" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'recommendpurchase']);">Recommend a Purchase</a></li>
 			</ul>
 		</div>
-	</div>  
+	</div>
 </div>

--- a/app/views/catalog/_expand_search.html.erb
+++ b/app/views/catalog/_expand_search.html.erb
@@ -6,7 +6,7 @@
 		<div class="card-body">
 			<ul class="fa-ul">
 				<li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= @expanded_results['worldcat'][:url] %>" onclick="javascript:_paq.push(['trackEvent', 'expandsearch', 'WCL']);">Request from Libraries Worldwide (<%= number_with_delimiter(@expanded_results['worldcat'][:count]) %>+)</a></li>
-				<li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= @expanded_results['summon'][:url] %>"onclick="javascript:_paq.push(['trackEvent', 'expandsearch', 'Summon']);">Search Articles &amp; Full Text (<%= number_with_delimiter(@expanded_results['summon'][:count]) %>)</a></li>
+				<li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= bento_all_results_link('ebsco_ds') %>"onclick="javascript:_paq.push(['trackEvent', 'expandsearch', 'EDS']);">Search Articles &amp; Full Text</a></li>
 				<li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="http://www.library.cornell.edu/services/request/recommend" onclick="javascript:_paq.push(['trackEvent', 'expandsearch', 'recommendpurchase']);">Recommend a Purchase</a></li>
 			</ul>
 		</div>


### PR DESCRIPTION
Articles & Text links in search results pages (advanced and regular) now link to EDS