### PR TITLE
Discoveryaccess 5656c - advanced search Articles & Full Text link target

### DIFF
--- a/app/helpers/single_search_helper.rb
+++ b/app/helpers/single_search_helper.rb
@@ -49,9 +49,13 @@ module SingleSearchHelper
       link = 'http://guides.library.cornell.edu/libguides/home'
     when "ebsco_ds"
       bq = ss_encode(params[:q] || params[:query])
-      edsq = {direct: true, authtype: "ip,uid", profile: "eds", bQuery: bq,
-        custid: "s9001366", groupid: "main" }
-      edsuri = URI::HTTP.build(host: 'search.ebscohost.com', query: URI.encode_www_form(edsq))
+      if bq.present?
+        edsq = {direct: true, authtype: "ip,uid", profile: "eds", bQuery: bq,
+          custid: "s9001366", groupid: "main" }
+        edsuri = URI::HTTP.build(host: 'search.ebscohost.com', query: URI.encode_www_form(edsq))
+      else
+        edsuri = 'http://search.ebscohost.com/login.aspx?authtype=ip,guest&profile=eds&Groupid=main&custid=s9001366'
+      end
       link = 'http://encompass.library.cornell.edu/cgi-bin/checkIP.cgi?access=gateway_standard%26url=' + edsuri.to_s
     when "summon_bento"
       link = "#"


### PR DESCRIPTION
When there is no simple query, as for advanced search, use a link to the EDS Search page instead of search results page with no query.