### PR TITLE
Discoveryaccess 5697 - EDS bento serch results linking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GIT
 
 GIT
   remote: https://github.com/cul-it/cul-my-account
-  revision: 0987cc066bebb28b9df46ed76ba29d95df2b2dd7
+  revision: 520c0a49b788bfb59d298d61c462d2195d05c8d9
   branch: dev
   specs:
     my_account (1.1.0)

--- a/app/item_decorators/bento_search/eds_article_decorator.rb
+++ b/app/item_decorators/bento_search/eds_article_decorator.rb
@@ -32,7 +32,16 @@ module BentoSearch
     end
 
   def render_citation_details
-    return nil
+    save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
+    Rails.logger.warn "jgr25_log #{__FILE__} #{__LINE__}: in EdsArticleDecorator render_citation_details"
+    puts 'custom_data: ' + self.custom_data.to_yaml
+    Rails.logger.level = save_level
+    result_elements = []
+    result_elements.push  self.custom_data[:citation_blob]
+
+    return nil if result_elements.empty?
+
+    return result_elements.join(", ").html_safe
   end
 
 end

--- a/app/item_decorators/bento_search/eds_article_decorator.rb
+++ b/app/item_decorators/bento_search/eds_article_decorator.rb
@@ -32,10 +32,6 @@ module BentoSearch
     end
 
   def render_citation_details
-    save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
-    Rails.logger.warn "jgr25_log #{__FILE__} #{__LINE__}: in EdsArticleDecorator render_citation_details"
-    puts 'custom_data: ' + self.custom_data.to_yaml
-    Rails.logger.level = save_level
     result_elements = []
     result_elements.push  self.custom_data[:citation_blob]
 
@@ -48,10 +44,6 @@ module BentoSearch
   # Mix-in a default missing title marker for empty titles
   # (Used to combine title and subtitle when those were different fields)
   def complete_title
-    save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
-    Rails.logger.warn "jgr25_log #{__FILE__} #{__LINE__}: in EdsArticleDecorator complete_title"
-    puts 'self: ' + self.to_yaml
-    Rails.logger.level = save_level
     if self.title.present?
       self.title
     else

--- a/app/item_decorators/bento_search/eds_article_decorator.rb
+++ b/app/item_decorators/bento_search/eds_article_decorator.rb
@@ -16,9 +16,9 @@ module BentoSearch
         parts << ". "
       end
 
-      # if text = self.render_citation_details
-      #   parts << text << "."
-      # end
+      if text = self.render_citation_details
+        parts << text << "."
+      end
 
       return _h.safe_join(parts, "")
     end

--- a/app/item_decorators/bento_search/eds_article_decorator.rb
+++ b/app/item_decorators/bento_search/eds_article_decorator.rb
@@ -44,5 +44,20 @@ module BentoSearch
     return result_elements.join(", ").html_safe
   end
 
+  # debugging jgr25
+  # Mix-in a default missing title marker for empty titles
+  # (Used to combine title and subtitle when those were different fields)
+  def complete_title
+    save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
+    Rails.logger.warn "jgr25_log #{__FILE__} #{__LINE__}: in EdsArticleDecorator complete_title"
+    puts 'self: ' + self.to_yaml
+    Rails.logger.level = save_level
+    if self.title.present?
+      self.title
+    else
+      I18n.translate("bento_search.missing_title")
+    end
+  end
+
 end
 end

--- a/app/item_decorators/bento_search/eds_article_decorator.rb
+++ b/app/item_decorators/bento_search/eds_article_decorator.rb
@@ -40,16 +40,5 @@ module BentoSearch
     return result_elements.join(", ").html_safe
   end
 
-  # debugging jgr25
-  # Mix-in a default missing title marker for empty titles
-  # (Used to combine title and subtitle when those were different fields)
-  def complete_title
-    if self.title.present?
-      self.title
-    else
-      I18n.translate("bento_search.missing_title")
-    end
-  end
-
 end
 end

--- a/app/search_engines/bento_search/eds_engine.rb
+++ b/app/search_engines/bento_search/eds_engine.rb
@@ -202,6 +202,8 @@ class BentoSearch::EdsEngine
     begin
       with_session(end_user_auth) do |session_token|
 
+        hit_count = args[:per_page]
+        args[:per_page] = hit_count * 7
         url = construct_search_url(args)
 
         response = get_with_auth(url, session_token)
@@ -213,6 +215,13 @@ class BentoSearch::EdsEngine
         end
 
         response.xpath("./SearchResponseMessageGet/SearchResult/Data/Records/Record").each do |record_xml|
+
+          # remove restricted results titled 'Record Not Available -- log in to see full results'
+          access_level = record_xml.at_xpath("./Header/AccessLevel").try(:text)
+          next if access_level.to_i < 3
+          hit_count -= 1
+          break if hit_count < 0
+
           item = BentoSearch::ResultItem.new
 
           item.title   = prepare_eds_payload( element_by_group(record_xml, "Ti"), true )
@@ -440,8 +449,7 @@ class BentoSearch::EdsEngine
               :url => original_item_link,
               :label => 'Original Link'
             )
-           end
-
+          end
           results << item
         end
       end

--- a/app/search_engines/bento_search/eds_engine.rb
+++ b/app/search_engines/bento_search/eds_engine.rb
@@ -415,6 +415,7 @@ class BentoSearch::EdsEngine
 
           # replace the link into EDS search with link to full text
           found = false
+          original_item_link = item.link
           item.other_links.each { |link|
             if link.label =~ /online access/i || link.label =~ /access url/i
               item.link = link.url
@@ -433,7 +434,13 @@ class BentoSearch::EdsEngine
               end
             }
           end
-          item.other_links = []
+          # item.other_links = []
+          if item.other_links.present?
+            item.other_links << BentoSearch::Link.new(
+              :url => original_item_link,
+              :label => 'Original Link'
+            )
+           end
 
           results << item
         end

--- a/app/search_engines/bento_search/eds_engine.rb
+++ b/app/search_engines/bento_search/eds_engine.rb
@@ -422,7 +422,9 @@ class BentoSearch::EdsEngine
 
           item.extend CitationMessDecorator
 
-          # item.other_links = []
+          # removes the links to Get It! Cornell and others from bottom of bento search result
+          item.other_links = []
+
           results << item
         end
       end

--- a/app/search_engines/bento_search/eds_engine.rb
+++ b/app/search_engines/bento_search/eds_engine.rb
@@ -422,34 +422,7 @@ class BentoSearch::EdsEngine
 
           item.extend CitationMessDecorator
 
-          # replace the link into EDS search with link to full text
-          found = false
-          original_item_link = item.link
-          item.other_links.each { |link|
-            if link.label =~ /online access/i || link.label =~ /access url/i
-              item.link = link.url
-              item.link_is_fulltext = true
-              found = true
-              break
-            end
-          }
-          if !found
-            item.other_links.each { |link|
-              if link.label =~ /full text/i
-                item.link = link.url
-                item.link_is_fulltext = true
-                found = true
-                break
-              end
-            }
-          end
           # item.other_links = []
-          if item.other_links.present?
-            item.other_links << BentoSearch::Link.new(
-              :url => original_item_link,
-              :label => 'Original Link'
-            )
-          end
           results << item
         end
       end


### PR DESCRIPTION
Get rid of 'Record Not Available -- log in to see full results' bento results for EDS
Also, link into EDS search results from Bento Articles & Text results, not to full text, due to authorization problems.