### PR TITLE
Discoveryaccess 5430 - undefined method 'catalog_index_url' rss crash

### DIFF
--- a/app/views/catalog/show.rss.builder
+++ b/app/views/catalog/show.rss.builder
@@ -4,7 +4,7 @@ xml.rss(:version=>"2.0") {
   xml.channel {
 
     xml.title(t('blacklight.search.title', :application_name => application_name))
-    xml.link(catalog_index_url(params))
+    xml.link(search_action_url(params.to_unsafe_h))
     xml.description(t('blacklight.search.title', :application_name => application_name))
     xml.language('en-us')
     @document_list = [@document]

--- a/app/views/catalog/show.rss.builder
+++ b/app/views/catalog/show.rss.builder
@@ -1,20 +1,20 @@
 xml.instruct! :xml, :version=>"1.0"
 xml.rss(:version=>"2.0") {
-        
+
   xml.channel {
-          
+
     xml.title(t('blacklight.search.title', :application_name => application_name))
     xml.link(catalog_index_url(params))
     xml.description(t('blacklight.search.title', :application_name => application_name))
     xml.language('en-us')
     @document_list = [@document]
     @document_list.each do |doc|
-      xml.item do  
-        xml.title( doc.to_semantic_values[:title][0] || doc.id )                              
+      xml.item do
+        xml.title( doc.to_semantic_values[:title][0] || doc.id )
         xml.link('/catalog/'+doc.id)
-        xml.author( doc.to_semantic_values[:author][0] ) if doc.to_semantic_values[:author][0]       
+        xml.author( doc.to_semantic_values[:author][0] ) if doc.to_semantic_values[:author][0]
       end
     end
-          
+
   }
 }


### PR DESCRIPTION
Avoid crash on access to /catalog/6112378.rss by replacing undefined method `catalog_index_url'