### PR TITLE
DISCOVERYACCESS-5780

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,9 +3,9 @@ class CatalogController < ApplicationController
 
   include BlacklightRangeLimit::ControllerOverride
   include Blacklight::Catalog
-  include Blacklight::DefaultComponentConfiguration
 #  include Blacklight::SearchHelper
   include BlacklightCornell::CornellCatalog
+  include Blacklight::DefaultComponentConfiguration
   include BlacklightUnapi::ControllerExtension
 
   if   ENV['SAML_IDP_TARGET_URL']


### PR DESCRIPTION
Reorder the list of classes/modules so that CornellCatalog precedes DefaultComponentConfiguration.