### PR TITLE
handle supressed or missing records

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -86,7 +86,7 @@ end
   def tou
     clnt = HTTPClient.new
     Appsignal.increment_counter('db_tou', 1)
-    Rails.logger.info("jac244 #{__FILE__} #{__LINE__}  = #{Blacklight.connection_config.inspect}")
+    Rails.logger.info("JAC244 #{__FILE__} #{__LINE__}  = #{Blacklight.connection_config.inspect}")
     solr = Blacklight.connection_config[:url]
     p = {"id" =>params[:id] , "wt" => 'json',"indent"=>"true"}
     @dbString = clnt.get_content("#{solr}/database?"+p.to_param)
@@ -133,7 +133,6 @@ end
         end
      end
    else
-    Rails.logger.info("StankyButters = #{@dbResponse['response']['docs']}")
     @defaultRightsText = "DatabaseCode and ProviderCode returns nothing"
    end
    @column_names = ::Erm_data.column_names.collect(&:to_sym)

--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -84,10 +84,9 @@ class DatabasesController < ApplicationController
 end
 
   def tou
-
     clnt = HTTPClient.new
     Appsignal.increment_counter('db_tou', 1)
-    Rails.logger.info("es287_debug #{__FILE__} #{__LINE__}  = #{Blacklight.connection_config.inspect}")
+    Rails.logger.info("jac244 #{__FILE__} #{__LINE__}  = #{Blacklight.connection_config.inspect}")
     solr = Blacklight.connection_config[:url]
     p = {"id" =>params[:id] , "wt" => 'json',"indent"=>"true"}
     @dbString = clnt.get_content("#{solr}/database?"+p.to_param)
@@ -107,9 +106,9 @@ end
           else
             providercode = possibleprovidercode
             dbcode = ActiveSupport::JSON.decode(@dbResponse['response']['docs'][0]['url_access_json'][0])['dbcode']
-            Rails.logger.info("PASSKET = #{dbcode}")
+        #    Rails.logger.info("PASSKET = #{dbcode}")
             @ermDBResult = ::Erm_data.where(Database_Code: dbcode, Provider_Code: providercode, Prevailing: 'true')
-            Rails.logger.info("CASKETKEY #{__FILE__} #{__LINE__} ermDBResult with db code  = #{@ermDBResult.inspect}")
+         #   Rails.logger.info("CASKETKEY #{__FILE__} #{__LINE__} ermDBResult with db code  = #{@ermDBResult.inspect}")
             if @ermDBResult.size < 1
               #@ermDBResult = ::Erm_data.where("Provider_Code = :pvc AND Prevailing = 'true' AND (Database_Code =  '' OR Database_Code IS NULL)",pvc: providercode[0])
               @ermDBResult = ::Erm_data.where(Database_Code: ['',nil], Provider_Code: providercode, Prevailing: 'true')
@@ -133,6 +132,9 @@ end
           end
         end
      end
+   else
+    Rails.logger.info("StankyButters = #{@dbResponse['response']['docs']}")
+    @defaultRightsText = "DatabaseCode and ProviderCode returns nothing"
    end
    @column_names = ::Erm_data.column_names.collect(&:to_sym)
 

--- a/app/views/databases/tou.html.erb
+++ b/app/views/databases/tou.html.erb
@@ -3,6 +3,10 @@
 <div class="row database-subject">
   <div class="page-title col-sm-12">
     <div class="return-link">
+       <% if !@db.present? %>
+         <%= @defaultRightsText.to_s %>
+         <br>
+       <% end %>
       <%= link_to "/databases/" do %>
         <i class="fa fa-arrow-circle-left"></i>
         Back to Databases

--- a/features/catalog_search/bookmarks.feature
+++ b/features/catalog_search/bookmarks.feature
@@ -11,12 +11,12 @@ Feature: Bookmarks for anonymous users
         Then Sign in should link to Book Bags
         And I should see a link "Selected Items"
 
-    #@saml_on
+    @saml_on
     @bookmarks_sign_in
     Scenario: If I try to sign in, I have to log in
         When I literally go to bookmarks
-        And click on link "Sign in"
-        Then I should see the CUWebLogin page
+        Then Sign in should link to Book Bags
+
 
 #    @bookmarks_select_items
 #    Scenario Outline: I can see the count of my selected items


### PR DESCRIPTION
Handle case where a direct link to terms of use points to a non-existent, suppressed, or record without dbcode and provider_code