### PR TITLE
Discoveryaccess 5998g - remove debug code - mySql Book Bags

### DIFF
--- a/app/controllers/book_bags_controller.rb
+++ b/app/controllers/book_bags_controller.rb
@@ -152,8 +152,6 @@ class BookBagsController < CatalogController
       docs = @bms.map {|b| b.sub!("bibid-",'')}
     end
 
-    addbookmarks unless params[:move_bookmarks].nil?
-
     if docs.present?
       @bookmarks = docs.map {|b| Bookmarklite.new(b)}
       @response,@documents = search_service.fetch docs

--- a/app/views/book_bags/index.html.erb
+++ b/app/views/book_bags/index.html.erb
@@ -17,7 +17,6 @@
     <%= link_to 'Sign in to enable your Book Bag', user_saml_omniauth_authorize_path, :data => {:toggle => 'tooltip', :placement => 'bottom'}, :title => 'Sign in to email items or save them to Book Bag', :onclick => "javascript:_paq.push(['trackEvent', 'header_links', 'Sign in']);" %>
   <% else %>
     <% bookmarks = session[:bookmarks_for_book_bags] %>
-    <%= bookmarks.inspect %>
     <% if bookmarks.present? && bookmarks.count > 0 %>
       <%= link_to addbookmarks_index_path, :data => { :confirm => t('blacklight.bookmarks.bag.action_confirm', count: bookmarks.count ) }, :class => 'add-bookmarks' do %>
             <i class="fa fa-bookmark"></i> <%= t('blacklight.bookmarks.bag.action_confirm', count: bookmarks.count ) %>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -19,7 +19,7 @@
         <% end %>
       <% end %>
 
-      <% if !(current_user && BookBag.enabled?) %>
+      <% if !current_user %>
       <li>
       <%= link_to bookmarks_path, {id:'bookmarks_nav'} do %>
               <%= t('blacklight.header_links.bookmarks') %>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -30,10 +30,10 @@
       <li>
       <%= link_to "/book_bags/index", id:'book_bags_nav' do %>
             <% @selectedcount =
-              if user_session.nil? || user_session[:bookbag_count].nil?
-                0
-              else
+              if BookBag.enabled? && user_session.present? && user_session[:bookbag_count].present?
                 user_session[:bookbag_count]
+              else
+                '?'
               end
               %>
             <span>Book Bag (<span data-role='bookmark-counter'><%= @selectedcount %></span>)</span>

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -96,7 +96,7 @@ Feature: Book Bags for logged in users
     Examples:
         | page |
         | the home page  |
-        | the bookmarks page |
+        # | the bookmarks page | - redirects to book bags
         | the detail page for id 11153474 |
         | the search history page |
         | the search everything page |

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -83,23 +83,23 @@ Feature: Book Bags for logged in users
         Then there should be 5 items in the BookBag
         And I should see 'Professional rope access : a guide to working safely at height'
 
-    # @book_bags_sign_in_anywhere
-    # Scenario Outline: I should be able to log in with the test user from any page
-    #     Given we are in any development or test environment
-    #     And the test user is available
-    #     And I go to <page>
-    #     And I sign in
-    #     Then I should see "You are logged in as Diligent Tester."
-    #     And navigation should show 'Book Bag'
-    #     And I sign out
+    @book_bags_sign_in_anywhere
+    Scenario Outline: I should be able to log in with the test user from any page
+        Given we are in any development or test environment
+        And the test user is available
+        And I go to <page>
+        And I sign in
+        Then I should see "You are logged in as Diligent Tester."
+        And navigation should show 'Book Bag'
+        And I sign out
 
-    # Examples:
-    #     | page |
-    #     | the home page  |
-    #     | the bookmarks page |
-    #     | the detail page for id 11153474 |
-    #     | the search history page |
-    #     | the search everything page |
+    Examples:
+        | page |
+        | the home page  |
+        | the bookmarks page |
+        | the detail page for id 11153474 |
+        | the search history page |
+        | the search everything page |
 
 
     @book_bags_cite_selected


### PR DESCRIPTION
mySql Book Bags
Remove some debug output code & display Book Bags instead of Selected Items in nav whenever logged in.