### PR TITLE
Discoveryaccess 6170 - fix for appsignal issue plus BookBag test

### DIFF
--- a/app/helpers/cornell_catalog_helper.rb
+++ b/app/helpers/cornell_catalog_helper.rb
@@ -1610,14 +1610,16 @@ end
 	holdArray = document['holdings_display'].to_a
 
 	col_loc = []
-	holdArray = holdArray[0].split('|')
-	holdArray.each do |holding|
-	  col_loc << holdings_condensed[holding]["call"] unless holdings_condensed[holding].nil?
-	  location = Hash(holdings_condensed[holding])
+	if holdArray.any?
+		holdArray = holdArray[0].split('|')
+		holdArray.each do |holding|
+			col_loc << holdings_condensed[holding]["call"] unless holdings_condensed[holding].nil?
+			location = Hash(holdings_condensed[holding])
 
-	  if location["location"].present? && location["location"]["name"].present?
-			col_loc << location["location"]["name"]
-	  end
+			if location["location"].present? && location["location"]["name"].present?
+					col_loc << location["location"]["name"]
+			end
+		end
 	end
 
 	description = []

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -63,21 +63,22 @@ Feature: Book Bags for logged in users
         And I empty the BookBag
         Then the BookBag should be empty
         When I go to the home page
-        And I fill in the search box with 'rope work'
+        And I fill in the search box with 'rope work guide'
         And I press 'search'
+        And I sleep 2 seconds
         Then I should get results
-        And I should see 'Professional rope access : a guide to working safely at height'
+        And I should see 'Professional Rope Access: A Guide To Working Safely at Height'
         And I select the first 5 catalog results
         And I sleep 5 seconds
         When I go to BookBag
         Then there should be 5 items in the BookBag
-        And I should see 'Professional rope access : a guide to working safely at height'
+        And I should see 'Professional Rope Access: A Guide To Working Safely at Height'
         Then I sign out
         And I go to the home page
         And I sign in to BookBag
         When I go to BookBag
         Then there should be 5 items in the BookBag
-        And I should see 'Professional rope access : a guide to working safely at height'
+        And I should see 'Professional Rope Access: A Guide To Working Safely at Height'
 
     @book_bags_sign_in_anywhere
     Scenario Outline: I should be able to log in with the test user from any page


### PR DESCRIPTION
BookBag test fails due to new case sensitivity for titles, shuffle of search result position, and slower searches.
Also fixes template error for /catalog.rss