### PR TITLE
DISCOVERYACCESS-6680 - test fixes for Jenkins aws plus

### DIFF
--- a/app/views/catalog/_expand_advanced_search.html.erb
+++ b/app/views/catalog/_expand_advanced_search.html.erb
@@ -6,7 +6,7 @@
 		<div class="card-body">
 			<ul class="fa-ul">
 			    <li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= ENV['WORLDCAT_URL'] %>" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'WCL']);">Search Libraries Worldwide</a></li>
-			    <li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= bento_all_results_link('ebsco_eds') %>" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'EDS']);">Search Articles &amp; Full Text (eds)</a></li>
+			    <li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= bento_all_results_link('ebsco_eds') %>" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'EDS']);">Search Articles &amp; Full Text</a></li>
 			    <li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="http://www.library.cornell.edu/services/request/recommend" onclick="javascript:_paq.push(['trackEvent', 'expandadvsearch', 'recommendpurchase']);">Recommend a Purchase</a></li>
 			</ul>
 		</div>

--- a/app/views/catalog/_expand_search.html.erb
+++ b/app/views/catalog/_expand_search.html.erb
@@ -6,7 +6,7 @@
 		<div class="card-body">
 			<ul class="fa-ul">
 				<li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= @expanded_results['worldcat'][:url] %>" onclick="javascript:_paq.push(['trackEvent', 'expandsearch', 'WCL']);">Request from Libraries Worldwide (<%= number_with_delimiter(@expanded_results['worldcat'][:count]) %>+)</a></li>
-				<li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= bento_all_results_link('ebsco_eds') %>"onclick="javascript:_paq.push(['trackEvent', 'expandsearch', 'EDS']);">Search Articles &amp; Full Text (eds) (<%= number_with_delimiter(bento_eds_count()) %>)</a></li>
+				<li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="<%= bento_all_results_link('ebsco_eds') %>"onclick="javascript:_paq.push(['trackEvent', 'expandsearch', 'EDS']);">Search Articles &amp; Full Text (<%= number_with_delimiter(bento_eds_count()) %>)</a></li>
 				<li><i class="fa fa-arrow-right" aria-hidden="true"></i><a href="http://www.library.cornell.edu/services/request/recommend" onclick="javascript:_paq.push(['trackEvent', 'expandsearch', 'recommendpurchase']);">Recommend a Purchase</a></li>
 			</ul>
 		</div>

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -51,7 +51,8 @@ Feature: Book Bags for logged in users
     Scenario: Bookmarks redirect logged in users to Book Bags
         Given we are in any development or test environment
         And I sign in to BookBag
-        Then navigation should show 'Book Bag'
+        Then I should see "You are logged in as Diligent Tester."
+        And navigation should show 'Book Bag'
         And I view my bookmarks
         Then I should see "Please use Book Bag while you are signed in."
         And navigation should show 'Book Bag'

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -34,8 +34,8 @@ Feature: Book Bags for logged in users
         And I press 'search'
         Then I should get results
         And I select the first <count> catalog results
-        Then I clear the SQLite transactions
         And I sleep <sleep> seconds
+        Then I clear the SQLite transactions
         Then navigation should show Book Bag contains <count>
         When I go to BookBag
         Then there should be <count> items in the BookBag

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -41,7 +41,7 @@ Feature: Book Bags for logged in users
 
     Examples:
     | count | sleep |
-    | 3 | 5 |
+    | 3 | 6 |
     | 4 | 6 |
     | 5 | 6 |
     | 10 | 6 |

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -34,7 +34,8 @@ Feature: Book Bags for logged in users
         And I press 'search'
         Then I should get results
         And I select the first <count> catalog results
-        And I sleep <sleep> seconds
+        Then I clear the SQLite transactions
+        # And I sleep <sleep> seconds
         Then navigation should show Book Bag contains <count>
         When I go to BookBag
         Then there should be <count> items in the BookBag

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -35,7 +35,7 @@ Feature: Book Bags for logged in users
         Then I should get results
         And I select the first <count> catalog results
         Then I clear the SQLite transactions
-        # And I sleep <sleep> seconds
+        And I sleep <sleep> seconds
         Then navigation should show Book Bag contains <count>
         When I go to BookBag
         Then there should be <count> items in the BookBag
@@ -44,8 +44,8 @@ Feature: Book Bags for logged in users
     | count | sleep |
     | 3 | 6 |
     | 4 | 6 |
-    | 5 | 6 |
-    | 10 | 6 |
+    | 5 | 8 |
+    | 10 | 8 |
     | 20 | 9 |
 
     @book_bags_bookmarks_redirect

--- a/features/single_search/search.feature
+++ b/features/single_search/search.feature
@@ -57,5 +57,5 @@ Feature: Search
       | Hunting, Gathering, and Stone Age Cooking | |
       | Norton Anthology of World Religions: Islam | |
       | Lions' Plate: TikTok's Whipped Coffee | |
-  #    | UTICA ZOO ANNOUNCES LIMITED EDITION 'LION'S ROAST' COFFEE, SUPPORTS AFRICAN LION CONSERVATION | |
+      | Utica Zoo, Utica Coffee Roasting | |
 

--- a/features/step_definitions/single_search/search_steps.rb
+++ b/features/step_definitions/single_search/search_steps.rb
@@ -24,18 +24,22 @@ Then /^I should not get bento results$/ do
 end
 
 Then("Articles & Full Text should list {string}") do |string|
-    within("div#ebsco_eds-Bento2") do
-      expect(page.first("h3.bento_item_title", :text => string))
-    end
+  # don't require "Articles & Full Text" to be in second column
+  eds_bento = page.find("div#ebsco_eds").first(:xpath,".//..")
+  within(eds_bento) do
+    expect(page.first("h3.bento_item_title", :text => string))
+  end
 end
 
 Then("Articles & Full Text should not list {string}") do |string|
+  # don't require "Articles & Full Text" to be in second column
+  eds_bento = page.find("div#ebsco_eds").first(:xpath,".//..")
   begin
-    within("div#ebsco_eds-Bento2") do
+    within(eds_bento) do
       expect(page).not_to have_selector("h3.bento_item_title", :text => string)
     end
   rescue Capybara::ElementNotFound => e
-    expect(page).not_to have_selector("div#ebsco_eds-Bento2")
+    expect(page).not_to have_selector(eds_bento)
   end
 end
 

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -124,9 +124,7 @@ Then /^there should be ([0-9]+) items selected$/ do |int|
 end
 
 Then("navigation should show Book Bag contains {int}") do |int|
-  patiently do
-    expect(page.find('a#book_bags_nav > span > span').text).to eq(int.to_s)
-  end
+  page.find('a#book_bags_nav > span > span', text: "#{int.to_s}")
 end
 
 Then /^navigation should( not)? show '([^']*)'$/ do |negation, string|

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -124,7 +124,9 @@ Then /^there should be ([0-9]+) items selected$/ do |int|
 end
 
 Then("navigation should show Book Bag contains {int}") do |int|
-  page.find('a#book_bags_nav > span > span', text: "#{int.to_s}")
+  patiently do
+    expect(page.find('a#book_bags_nav > span > span').text).to eq(int.to_s)
+  end
 end
 
 Then /^navigation should( not)? show '([^']*)'$/ do |negation, string|


### PR DESCRIPTION
DISCOVERYACCESS-6680 - Ensure cucumber tests run on AWS
DISCOVERYACCESS-6676 - Remove (eds) from link for ‘Search Articles & Full Text’ link under ‘Looking for more?’
DISCOVERYACCESS-6677 - Do not require "Articles & Full Text" to be in second column for bento test step