### PR TITLE
Discoveryaccess 5988 d - inconsequential change and rename of branch

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,7 +29,7 @@ set :bundle_flags,    "--deployment "
 require 'bundler/capistrano'
 require 'capistrano/ext/multistage'
 
-set :stages, ["integration","development","integration-aws","integration-ld4p3","staging", "production","production-new"]
+set :stages, ["integration","development","integration-aws","integration-ld4p3","staging", "production","production-new","production-aws"]
 set :default_stage, "staging"
 default_run_options[:pty] = true
 

--- a/config/deploy/production-aws.rb
+++ b/config/deploy/production-aws.rb
@@ -1,4 +1,4 @@
-# new servers that reside in aws
+
 server 'newcatalog8.library.cornell.edu', :app, :web, :db, user: 'jenkins' 
 server 'newcatalog9.library.cornell.edu', :app, :web, :db, user: 'jenkins' 
 server 'newcatalog0.library.cornell.edu', :app, :web, :db, user: 'jenkins' 

--- a/config/deploy/production-aws.rb
+++ b/config/deploy/production-aws.rb
@@ -1,3 +1,4 @@
+# new servers that reside in aws
 server 'newcatalog8.library.cornell.edu', :app, :web, :db, user: 'jenkins' 
 server 'newcatalog9.library.cornell.edu', :app, :web, :db, user: 'jenkins' 
 server 'newcatalog0.library.cornell.edu', :app, :web, :db, user: 'jenkins' 

--- a/config/deploy/production-aws.rb
+++ b/config/deploy/production-aws.rb
@@ -1,0 +1,11 @@
+server 'newcatalog8.library.cornell.edu', :app, :web, :db, user: 'jenkins' 
+server 'newcatalog9.library.cornell.edu', :app, :web, :db, user: 'jenkins' 
+server 'newcatalog0.library.cornell.edu', :app, :web, :db, user: 'jenkins' 
+
+set :deploy_to, "/cul/web/newcatalog-aws.library.cornell.edu/rails-app"
+#this avoids an error message from git, but i don't think it's really necessary.
+#as i don't think the message actually affects what gets installed.
+set :branch, ENV['GIT_BRANCH'].gsub("origin/","")
+task :install_env, :roles => [ :app, :db, :web ] do
+  run "cp #{deploy_to}/../conf/production.env  #{shared_path}/.env"
+end

--- a/features/catalog_search/book_bags.feature
+++ b/features/catalog_search/book_bags.feature
@@ -42,10 +42,10 @@ Feature: Book Bags for logged in users
 
     Examples:
     | count | sleep |
-    | 3 | 6 |
-    | 4 | 6 |
-    | 5 | 8 |
-    | 10 | 8 |
+    | 3 | 8 |
+    | 4 | 8 |
+    | 5 | 9 |
+    | 10 | 9 |
     | 20 | 9 |
 
     @book_bags_bookmarks_redirect

--- a/features/single_search/results_list.feature
+++ b/features/single_search/results_list.feature
@@ -236,6 +236,6 @@ Examples:
   | query | repository |
   | eye tracking | eCommons |
 #  | eye tracking | The Scholarly Commons |
-  | labor unrest | DigitalCommons@ILR |
+  | labor unrest | eCommons |
   | torts | Scholarship@Cornell Law |
   | barley | Agricultural Experiment Station |

--- a/features/single_search/results_list.feature
+++ b/features/single_search/results_list.feature
@@ -235,7 +235,6 @@ Scenario Outline: Search with institutional repository results for each IR
 Examples:
   | query | repository |
   | eye tracking | eCommons |
-#  | eye tracking | The Scholarly Commons |
   | labor unrest | eCommons |
   | torts | Scholarship@Cornell Law |
   | barley | Agricultural Experiment Station |


### PR DESCRIPTION
Removed a comment.
The branch name for this request is different (-d suffix) to try to avoid issue in Jenkins:

```
292 scenarios (292 passed)
1697 steps (1697 passed)
51m16.875s
Recording test results
[Checks API] No suitable checks publisher found.
The recommended git tool is: NONE
using credential 231bb33b-f4b7-4ae4-af92-46adb54398dd
 > /usr/bin/git tag -l pull_req/jenkins-blacklight-cornell-merge-pr-942/$CHANGE_ID # timeout=10
ERROR: Step ‘Git Publisher’ failed: Tag pull_req/jenkins-blacklight-cornell-merge-pr-942/$CHANGE_ID already exists and Create Tag is specified, so failing.
Setting status of 1a50fdf8d2a4b676e5c8075c26b668b2396bbbc3 to FAILURE with url https://awsjenkins.library.cornell.edu/job/blacklight-cornell-merge-pr/942/ and message: ' '
[Slack Notifications] found #941 as previous completed, non-aborted build
[Slack Notifications] will send OnEveryFailureNotification because build matches and user preferences allow it
Finished: FAILURE
```