### PR TITLE
DISCOVERYACCESS-6936 - Use parameterized SMTP information

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,8 +5,8 @@ require File.expand_path('../application', __FILE__)
 BlacklightCornell::Application.initialize!
 
 ActionMailer::Base.smtp_settings = {
-  :from => "culsearch@cornell.edu",
-  :address    => 'appsmtp.mail.cornell.edu',
+  :from => ENV["SMTP_FROM"],
+  :address    => ENV["SMTP_ADDRESS"],
 }
 MARC::XMLReader.nokogiri!
 BlacklightCornellRequests::VoyagerRequest.use_rest(true)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,7 +1,7 @@
 BlacklightCornell::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
  config.eager_load = false
- #config.eager_load = true 
+ #config.eager_load = true
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
@@ -19,11 +19,13 @@ BlacklightCornell::Application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.smtp_settings = {
-    :address => 'localhost',
-    :domain => 'cornell.edu',
-    :user_name => 'culsearch@cornell.edu'
+    address: ENV["SMTP_ADDRESS"],
+    port: ENV["SMTP_PORT"],
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
   }
-
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
   # See everything in the log (default is :info)
@@ -35,7 +37,7 @@ BlacklightCornell::Application.configure do
 
   # Raise exception on mass assignment protection for Active Record models
   #config.active_record.mass_assignment_sanitizer = :strict
-  #config.active_record.mass_assignment_sanitizer = false 
+  #config.active_record.mass_assignment_sanitizer = false
 
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
@@ -46,7 +48,7 @@ BlacklightCornell::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
-  
+
   # this allows WEBrick to handle pipe symbols in query parameters
 #URI::DEFAULT_PARSER = URI::Parser.new(:UNRESERVED => URI::REGEXP::PATTERN::UNRESERVED + '|')
 

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -56,9 +56,12 @@ BlacklightCornell::Application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.smtp_settings = {
-    :address => 'appsmtp.mail.cornell.edu',
-    :domain => 'cornell.edu',
-    :user_name => 'culsearch@cornell.edu'
+    address: ENV["SMTP_ADDRESS"],
+    port: ENV["SMTP_PORT"],
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
   }
   # Enable threaded mode
   # config.threadsafe!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,9 +58,12 @@ BlacklightCornell::Application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.smtp_settings = {
-    :address => 'appsmtp.mail.cornell.edu',
-    :domain => 'cornell.edu',
-    :user_name => 'culsearch@cornell.edu'
+    address: ENV["SMTP_ADDRESS"],
+    port: ENV["SMTP_PORT"],
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
   }
   # Enable threaded mode
   # config.threadsafe!

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -54,9 +54,12 @@ BlacklightCornell::Application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.smtp_settings = {
-    :address => 'appsmtp.mail.cornell.edu',
-    :domain => 'cornell.edu',
-    :user_name => 'culsearch@cornell.edu'
+    address: ENV["SMTP_ADDRESS"],
+    port: ENV["SMTP_PORT"],
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
   }
   # Enable threaded mode
   # config.threadsafe!

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,9 +19,12 @@ BlacklightCornell::Application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.smtp_settings = {
-    :address => 'localhost',
-    :domain => 'cornell.edu',
-    :user_name => 'culsearch@cornell.edu'
+    address: ENV["SMTP_ADDRESS"],
+    port: ENV["SMTP_PORT"],
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
   }
 
   # Print deprecation notices to the Rails logger


### PR DESCRIPTION
Change the email host to something on AWS, and parameterize in .env.
nokogiri security update