### PR TITLE
DISCOVERYACCESS-6995 - change changelog since .env is not in git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [DISCOVERYACCESS-6995] - 2021-03-15
+### Changed
+DISCOVERYACCESS-6995 - change .env file settings: set SYNDETICS_UNBOUND_ENABLED=1 to turn on Syndetics Table of Contents feature


### PR DESCRIPTION
Changed .env on newcatalog-int-aws