### PR TITLE
DISCOVERYACCESS-7123 - add a version of item view that does NOT check…

### DIFF
--- a/features/catalog_search/search.feature
+++ b/features/catalog_search/search.feature
@@ -224,7 +224,7 @@ Feature: Search
     And I press 'search'
     And I sleep 8 seconds
     Then the search results should not contain title "<title>"
-    And I request the item view for <bibid>
+    And I attempt the item view for <bibid>
     Then I should see "Sorry, you have requested a record that doesn't exist."
 
   Examples:

--- a/features/step_definitions/item_view_steps.rb
+++ b/features/step_definitions/item_view_steps.rb
@@ -6,6 +6,11 @@ Given /^I request the item view for (.*?)$/ do |bibid|
   end
 end
 
+Given /^I attempt the item view for (.*?)$/ do |bibid|
+  # this version does not check for bibid exists
+  visit "/catalog/#{bibid}"
+end
+
 Given("I request the export of item {int} in {string} format") do |int, string|
   visit "/catalog/#{int}.#{string}"
 end


### PR DESCRIPTION
… for bibid exists

I added a check to the original version to detect missing bibids. The logic of this test is explicitly checking for bibids that are not supposed to be there.