### PR TITLE
Update deploy.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -94,7 +94,7 @@ desc "Guarantee app signal environment -- too sensitive for git"
 task :export_app_yml, :roles => [ :app, :db, :web ] do
          rails_env = fetch(:rails_env, "production")
          #run "cd  #{deploy_to}/current/ ; pwd ; export `grep APPSIGNAL_PUSH_API_KEY  .env`  ; echo $APPSIGNAL_PUSH_API_KEY ; bundle exec bin/appsignal notify_of_deploy --user=jenkins  --revision=#{ENV['GIT_COMMIT']} --environment=#{stage} --name=BlacklightCornell "
-	run "cd  #{current_path} ; pwd ; export `grep APPSIGNAL_PUSH_API_KEY  .env`  ; erb config/appsignal.yml > a ; mv a config/appsignal.yml;  cat config/appsignal.yml ;  echo $APPSIGNAL_PUSH_API_KEY ; bundle exec appsignal notify_of_deploy --user=jenkins  --revision=#{ENV['GIT_COMMIT']} --environment=#{stage} --name=BlacklightCornell "
+	run "cd  #{current_path} ; pwd ; export `grep APPSIGNAL_PUSH_API_KEY  .env`  ; erb config/appsignal.yml > a ; mv a config/appsignal.yml;  cat config/appsignal.yml ;  echo $APPSIGNAL_PUSH_API_KEY ; bundle exec appsignal notify_of_deploy --user=jenkins  --revision=#{ENV['GIT_COMMIT']} --environment=#{rails_env} --name=BlacklightCornell "
 end
 
 after :deploy, "tailor_solr_yml"


### PR DESCRIPTION
The old notification to AppSignal used "stage" as a key, which historically was always the same as "rails_env" but in recent years, I've had to use the former to tell Capistrano to distinguish between different sets of infrastructure (migration to aws, migration to folio, etc.) so they are always different now. This notification push causes AppSignal to spin up an entirely new application "stage" instead of just merging with the existing one, but the new one never gets used. This creates clutter in AppSignal. This commit will make sure the name of the AppSignal stage matches the rails_env.