### PR TITLE
Update production-ruby3.rb

### DIFF
--- a/config/deploy/production-ruby3.rb
+++ b/config/deploy/production-ruby3.rb
@@ -9,7 +9,8 @@ set :migration_servers, -> { release_roles(fetch(:migration_role)) }
 
 set :deploy_to, "/cul/web/newcatalog.library.cornell.edu/rails-app"
 
-set :branch, ENV['BRANCH'].gsub("origin/","") if ENV['BRANCH']
+#set :branch, ENV['BRANCH'].gsub("origin/","") if ENV['BRANCH']
+set :branch, ENV['GIT_BRANCH'].gsub("origin/","")
 
 set :rails_env, 'production'
 


### PR DESCRIPTION
When we're using a git branch selector parameter, it makes sense for Capistrano to pull the branch specified in that parameter rather than GIT_BRANCH. But when we take that selector away, that value will be null and so Cap will need to pull what's in GIT_BRANCH. 