### PR TITLE
DISCOVERYACCESS-8053

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -32,5 +32,6 @@
     </div>
     <div id="libchat_93c39d16c29840b40a8efdeaef81707f"></div>
     <script src="https://v2.libanswers.com/load_chat.php?hash=93c39d16c29840b40a8efdeaef81707f"></script>
+    <label id="page_load_label" class="checkbox" style="opacity:0; position:absolute; left:9999px;"><input id="page_load_check" type="checkbox" value="loaded" checked="false" style="opacity:0; position:absolute; left:9999px;">Page Loaded</label>
   </div>
 </footer>

--- a/features/assumption/javascript_loaded.feature
+++ b/features/assumption/javascript_loaded.feature
@@ -12,3 +12,31 @@ Scenario Outline: Page has loaded all javascript
 Examples:
     | page |
     | the home page  |
+    | the catalog page |
+    | the detail page for id 7981095 |
+    | BookBag |
+    | the search page |
+    | the search everything page |
+    | the search history page |
+    | the single search results page |
+
+
+@javascript
+Scenario Outline: Page at path has loaded all javascript
+    When I literally go to <path>
+    Then all javascript has loaded
+
+Examples:
+    | path |
+    | databases |
+    | databases/subject/History |
+    | credits |
+    | myaccount/login |
+
+@javascript
+Scenario: Perform a search and see call number facet
+    Given I am on the home page
+    And I fill in the search box with 'ocean'
+    And I press 'search'
+    Then I should get results
+    And all javascript has loaded

--- a/features/assumption/javascript_loaded.feature
+++ b/features/assumption/javascript_loaded.feature
@@ -1,0 +1,14 @@
+# encoding: UTF-8
+Feature: Javascript
+  In order to run javascript
+  As a user
+  I want to be sure all the javascript code has loaded correctly with the page
+
+@javascript
+Scenario Outline: Page has loaded all javascript
+    When I go to <page>
+    Then all javascript has loaded
+
+Examples:
+    | page |
+    | the home page  |

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -426,6 +426,14 @@ Given("I visit the Cite page for {int}") do |int|
 end
 
 Then("all javascript has loaded") do
-  execute_script("jQuery(window).on('load', function () { document.getElementById('page_load_check').checked = true; });")
+  # execute_script("jQuery(window).on('load', function () { document.getElementById('page_load_check').checked = true; });")
+  execute_script("let stateCheck = setInterval(() => {
+    if (document.readyState === 'complete') {
+      clearInterval(stateCheck);
+      // document ready
+      document.getElementById('page_load_check').checked = true;
+    }
+  }, 100);
+  ")
   expect(find('#page_load_label', visible: false)).to have_checked_field('page_load_check', visible: false);
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -424,3 +424,8 @@ end
 Given("I visit the Cite page for {int}") do |int|
 	do_visit("/catalog/#{int}/citation")
 end
+
+Then("all javascript has loaded") do
+  execute_script("jQuery(window).on('load', function () { document.getElementById('page_load_check').checked = true; });")
+  expect(find('#page_load_label', visible: false)).to have_checked_field('page_load_check', visible: false);
+end


### PR DESCRIPTION
This provides a checkbox in the page footer and some Javascript code in web_steps.rb that is supposed to check the box at the end of page loading. There are some tests to run this on several pages in features/assumption/javascript_loaded.feature

I have not been able to 'break' the Javascript so the tests detect that the page is not fully loaded. Maybe this whole theory is invalid - in that case I don't want to add this code to the project.

I'm not sure if the checkbox is going to mess up the accessibility of the page - I wanted it hidden from users.