### PR TITLE
Discoveryaccess 7501

### DIFF
--- a/app/helpers/display_helper.rb
+++ b/app/helpers/display_helper.rb
@@ -1177,35 +1177,22 @@ end
     end
   end
 
+  # TODO: no longer needed? commented out 5/31/23 to see if it breaks anything - mhk33, DISCOVERYACCESS-7501
   # Clean up isbn in prep for bookcovers via Google Books API
-  def bookcover_isbn(document)
-    isbn = document['isbn_display']
-    unless isbn.blank?
-      isbn = isbn.first
-      # Find first occurence of a space (remove non integer chars)
-      space = isbn.index(' ')
-      unless space.blank?
-        stop = space - 1
-        isbn[0..stop]
-      else
-        isbn
-      end
-    end
-  end
-
-  # Parse other_id_display field for OCLC numbers
-  def bookcover_oclc(document)
-    #Rails.logger.info("CONGAME = #{document.inspect}")
-#    Rails.logger.info("CONGAME = #{document['oclc_id_display']}")
-#    oclc_id = document['oclc_id_display'][0]
-    other_ids = document['other_id_display']
-    oclc_id = document['oclc_id_display'][0] #other_ids.find { |e| /^\(OCoLC\)/ =~ e } unless other_ids.blank?
-    unless oclc_id.blank?
-      # Remove '(OCLC)' prefix
-      # -- really need to ask Frances about making OCLC# its own field
-      oclc_id.gsub(/^\(OCoLC\)/, '')
-    end
-  end
+  # def bookcover_isbn(document)
+  #   isbn = document['isbn_display']
+  #   unless isbn.blank?
+  #     isbn = isbn.first
+  #     # Find first occurence of a space (remove non integer chars)
+  #     space = isbn.index(' ')
+  #     unless space.blank?
+  #       stop = space - 1
+  #       isbn[0..stop]
+  #     else
+  #       isbn
+  #     end
+  #   end
+  # end
 
   def bookcover_oclc(document)
     if document['oclc_id_display'].nil?

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,7 +1,6 @@
 <% # container for a single doc -%>
 <%- online_data = ( (is_online? document) ? "data-online='no'" : "data-online='no'") %>
 <%- atl_data = ( (is_at_the_library? document) ? "data-atl='yes'" : "data-atl='no'") %>
-<%- atl_data = ( (is_at_the_library? document) ? "data-atl='yes'" : "data-atl='no'") %>
 <div class="document <%= render_document_class document %> row" data-bibid="<%= document.id %>" <%= online_data.html_safe %> <%= atl_data.html_safe %> >
   <div class="document-data col-sm-10">
 	<%= render :partial => 'microformat_index', :locals => {:document => document } %>

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,6 +1,7 @@
 <% # container for a single doc -%>
 <%- online_data = ( (is_online? document) ? "data-online='no'" : "data-online='no'") %>
 <%- atl_data = ( (is_at_the_library? document) ? "data-atl='yes'" : "data-atl='no'") %>
+<%- atl_data = ( (is_at_the_library? document) ? "data-atl='yes'" : "data-atl='no'") %>
 <div class="document <%= render_document_class document %> row" data-bibid="<%= document.id %>" <%= online_data.html_safe %> <%= atl_data.html_safe %> >
   <div class="document-data col-sm-10">
 	<%= render :partial => 'microformat_index', :locals => {:document => document } %>
@@ -9,9 +10,11 @@
     <%= render_document_partial document, :index %>
   </div>
   <div class="col-sm-2">
-  	  <%# bookmark functions for items/docs -%>
-	  <%= render_index_doc_actions document, :wrapping_class => "select-item" %>
-	  <div class="bookcover" id="OCLC:<%= bookcover_oclc(document) %>" data-oclc="<%= bookcover_oclc(document) %>">
-	  </div>
+    <%# bookmark functions for items/docs -%>
+  	<%= render_index_doc_actions document, :wrapping_class => "select-item" %>
+    <% if document['oclc_id_display'].present? %>
+	   <div class="bookcover" id="OCLC:<%= bookcover_oclc(document) %>" data-oclc="<%= bookcover_oclc(document) %>">
+	   </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -2,18 +2,19 @@
 <%- online_data = ( (is_online? document) ? "data-online='no'" : "data-online='no'") %>
 <%- atl_data = ( (is_at_the_library? document) ? "data-atl='yes'" : "data-atl='no'") %>
 <div class="document <%= render_document_class document %> row" data-bibid="<%= document.id %>" <%= online_data.html_safe %> <%= atl_data.html_safe %> >
-  <div class="document-data col-sm-10">
-	<%= render :partial => 'microformat_index', :locals => {:document => document } %>
-    <%= render :partial => 'document_header', :locals => { :document => document, :document_counter => document_counter } %>
-    <% # main container for doc partial view -%>
-    <%= render_document_partial document, :index %>
-  </div>
-  <div class="col-sm-2">
-    <%# bookmark functions for items/docs -%>
-  	<%= render_index_doc_actions document, :wrapping_class => "select-item" %>
-    <% if document['oclc_id_display'].present? %>
-	   <div class="bookcover" id="OCLC:<%= bookcover_oclc(document) %>" data-oclc="<%= bookcover_oclc(document) %>">
-	   </div>
-    <% end %>
-  </div>
+	<div class="document-data col-sm-10">
+		<%= render :partial => 'microformat_index', :locals => {:document => document } %>
+		<%= render :partial => 'document_header', :locals => { :document => document, :document_counter => document_counter } %>
+		<% # main container for doc partial view -%>
+		<%= render_document_partial document, :index %>
+	</div>
+	<div class="col-sm-2">
+		<%# bookmark functions for items/docs -%>
+		<%= render_index_doc_actions document, :wrapping_class => "select-item" %>
+		<% oclc_num = bookcover_oclc(document) %>
+		<% if oclc_num.present? %>
+		<div class="bookcover" id="OCLC:<%= bookcover_oclc(document) %>" data-oclc="<%= bookcover_oclc(document) %>">
+		</div>
+		<% end %>
+	</div>
 </div>


### PR DESCRIPTION
Currently if we don't have a book cover in search results we output an empty div with an id `OCLC:`. This causes an accessibility error since these records have the same ID. Only output the bookcover div if we have `oclc_id_display`.