### PR TITLE
DISCOVERYACCESS-8076 - tests for thumbnails

### DIFF
--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -13,7 +13,7 @@
 		<%= render_index_doc_actions document, :wrapping_class => "select-item" %>
 		<% oclc_num = bookcover_oclc(document) %>
 		<% if oclc_num.present? %>
-		<div class="bookcover" id="OCLC:<%= bookcover_oclc(document) %>" data-oclc="<%= bookcover_oclc(document) %>">
+		<div class="bookcover" id="OCLC:<%= oclc_num %>" data-oclc="<%= oclc_num %>">
 		</div>
 		<% end %>
 	</div>

--- a/features/catalog_search/thumbnail.feature
+++ b/features/catalog_search/thumbnail.feature
@@ -6,13 +6,12 @@ Feature: Thumbnail images of the items are displayed when available
   I want to see any available image of the document cover
 
 @DISCOVERYACCESS-7501
-Scenario Outline: OCLC ids are attached to thumbnails
+Scenario Outline: Thumbnails are provided for some items with OCLC
     Given I am on the home page
     And I fill in the search box with 'music'
     And I press 'search'
     Then I should get results
     And I should see a thumbnail image for "<title>"
-    And the thumbnail image ID for "<title>" should be "<id>"
 
 Examples:
     | title | id |

--- a/features/catalog_search/thumbnail.feature
+++ b/features/catalog_search/thumbnail.feature
@@ -17,3 +17,11 @@ Examples:
     | title | id |
     | Stravinsky : a family chronicle : 1906-1940  | Value 2  |
     | Carly Simon's Romulus Hunt : a family opera ; vocal score | xx |
+
+@DISCOVERYACCESS-7501
+Scenario: Confirm eradication of an old bug with duplicate image ids
+  Given I am on the home page
+  And I fill in the search box with 'music'
+  And I press 'search'
+  Then I should get results
+  And all ids are unique

--- a/features/catalog_search/thumbnail.feature
+++ b/features/catalog_search/thumbnail.feature
@@ -1,0 +1,20 @@
+@thumbnail
+@javascript
+Feature: Thumbnail images of the items are displayed when available
+  In order to find documents
+  As a user
+  I want to see any available image of the document cover
+
+@DISCOVERYACCESS-7501
+Scenario Outline: OCLC ids are attached to thumbnails
+    Given I am on the home page
+    And I fill in the search box with 'music'
+    And I press 'search'
+    Then I should get results
+    And I should see a thumbnail image for "<title>"
+    And the thumbnail image ID for "<title>" should be "<id>"
+
+Examples:
+    | title | id |
+    | Stravinsky : a family chronicle : 1906-1940  | Value 2  |
+    | Carly Simon's Romulus Hunt : a family opera ; vocal score | xx |

--- a/features/step_definitions/results_list_steps.rb
+++ b/features/step_definitions/results_list_steps.rb
@@ -85,3 +85,21 @@ Then (/^I visit Books page '(.*)' with '(.*)' per page$/) do |page, perpage|
   href = "/?f[format][]=Book&page=#{page}&per_page=#{perpage}"
 	do_visit(href)
 end
+
+Then("I should see a thumbnail image for {string}") do |string|
+  within ('div#documents.documents-list') do
+    link = find(:xpath, '//h2/a', :text => string)
+    document = link.first(:xpath, ".//../../..")
+    expect(document).to have_selector('img.img-thumbnail')
+  end
+end
+
+Then("the thumbnail image ID for {string} should be {string}") do |string, string2|
+  within ('div#documents.documents-list') do
+    # link = find(:xpath, '//h2/a', :text => string).first(:xpath, ".//../../..").find(:xpath, ".//div/img")
+    link = find(:xpath, '//h2/a', :text => string)
+    document = link.first(:xpath, ".//../../..")
+    expect(document).to have_selector('img.img-thumbnail', :id => string2)
+  end
+end
+

--- a/features/step_definitions/results_list_steps.rb
+++ b/features/step_definitions/results_list_steps.rb
@@ -94,12 +94,14 @@ Then("I should see a thumbnail image for {string}") do |string|
   end
 end
 
-Then("the thumbnail image ID for {string} should be {string}") do |string, string2|
-  within ('div#documents.documents-list') do
-    # link = find(:xpath, '//h2/a', :text => string).first(:xpath, ".//../../..").find(:xpath, ".//div/img")
-    link = find(:xpath, '//h2/a', :text => string)
-    document = link.first(:xpath, ".//../../..")
-    expect(document).to have_selector('img.img-thumbnail', :id => string2)
+Then("all ids are unique") do
+  ids = []
+  page.all("*", :id => /.+/).each do |el|
+    id = el[:id]
+    if ids.include? id
+        fail('not unique')
+    else
+      ids << id
+    end
   end
 end
-


### PR DESCRIPTION
Tests to confirm that bugs fixed by https://culibrary.atlassian.net/browse/DISCOVERYACCESS-7501 are gone.

- Thumbnail images are present for some item.
- There are no duplicate IDs on a page.