### PR TITLE
DISCOVERYACCESS-8028 - Filter query by headingType in browse#info

### DIFF
--- a/app/views/browse/info.html.erb
+++ b/app/views/browse/info.html.erb
@@ -16,6 +16,11 @@
       <% end %>
     </div>
   <% end %>
+  <!--
+  TODO (possible cleanup): Why are we trying to render every possible doc returned from the browse query?
+  Now that we're filtering by headingtype in the BrowseController, we should be able to send only the first doc to views
+  Instead of having to call @headingResponse[0] everywhere
+  -->
   <% @headingsResponse.each do |data| %>
     <% encoded_heading = (data["heading"]).gsub('&', '%26').gsub("\"", "'") %>
     <% if data["headingTypeDesc"] == params[:headingtype] || params[:headingtype].nil? %>

--- a/features/browse/browse_search.feature
+++ b/features/browse/browse_search.feature
@@ -15,6 +15,9 @@ Feature: Browse search
         And I fill in the authorities search box with 'Heaney, Seamus'
         And I press 'search'
     Then I should see the label 'Heaney, Seamus, 1939-2013'
+    Then click on first link "Author info"
+    Then I should see the label 'Heaney, Seamus, 1939-2013'
+    Then I should see the label 'Library Holdings'
 
   @browse
   Scenario: Search for a subject
@@ -23,6 +26,9 @@ Feature: Browse search
         And I select 'Subject Browse (A-Z)' from the 'browse_type' drop-down
         And I press 'search'
     Then I should see the label 'Wizards > Juvenile fiction'
+    Then click on first link "Subject info"
+    Then I should see the label 'Wizards > Juvenile fiction'
+    Then I should see the label 'Library Holdings'
 
   @browse
   @browse_search_switch


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DISCOVERYACCESS-8028

### Overview

Previously we were using the solr browse endpoint in subject and author searches without actually sending along the headingtype param. Most of the corresponding views just display the first doc returned by the response, which may not be the correct one. Updated the info action in BrowseController to properly filter by headingTypeDesc.

Also snuck in some cleanup:
- DRY-ed up browse#info across different browse types
- switched from connecting to solr with HttpClient to rsolr (for consistency with other controllers)
- added more checks for valid params to address related old AppSignal errors ([DISCOVERYACCESS-7899](https://culibrary.atlassian.net/browse/DISCOVERYACCESS-7899) and [DISCOVERYACCESS-7621](https://culibrary.atlassian.net/browse/DISCOVERYACCESS-7621))
- added a TODO for possible future cleanup of browse views

### Test examples
Subjects with same heading label but different heading type:
- /browse?authq=Motion%20pictures&browse_type=Subject&start=0
- /browse?utf8=✓&authq=Tourist+Maps&start=0&browse_type=Subject

[DISCOVERYACCESS-7899]: https://culibrary.atlassian.net/browse/DISCOVERYACCESS-7899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DISCOVERYACCESS-7621]: https://culibrary.atlassian.net/browse/DISCOVERYACCESS-7621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ