### PR TITLE
Fix CSRF token bug preventing Aeon requests from being submitted

### DIFF
--- a/app/views/layouts/aeon/_prelim.html.erb
+++ b/app/views/layouts/aeon/_prelim.html.erb
@@ -54,6 +54,7 @@
 						</ol>
 					</div>
 				</div>
+				<%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
 				<input type="hidden" id="ReferenceNumber" name="ReferenceNumber" value="<%= @bibid %>"/>
 				<input type="hidden" id="ItemNumber" name="ItemNumber" value=""/>
 				<input type="hidden" id="DocumentType" name="DocumentType" value="<%= @doctype %>"/>


### PR DESCRIPTION
A [previous commit](https://github.com/cul-it/blacklight-cornell/commit/b7374bc2308655e41d6d5b0f26372924c542b88d) changed the configuration of `protect_from_forgery` to raise an exception if an unsigned request was detected. The Aeon request form is, for now, manually assembled, and thus it presumably misses out on the automatic authenticity token handling that Rails provides. We need to explicitly add the token to the form to avoid getting blocked by CSRF security.

(The Aeon forms probably need to be rewritten anyway, perhaps to make use of the Aeon API that's available.)