### PR TITLE
DISCOVERYACCESS-8118 - Advanced search fixes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -509,7 +509,7 @@ end
 #        :pf => '$publisher_pf'
       }
     end
-    config.add_search_field('place of publication') do |field|
+    config.add_search_field('pubplace', :label => 'Place of Publication') do |field|
        field.include_in_simple_select = false
        field.solr_local_parameters = {
 #         :qf => '$pubplace_qf',
@@ -538,7 +538,7 @@ end
        }
     end
 
-    config.add_search_field('donor name') do |field|
+    config.add_search_field('donor', :label => 'Donor Name') do |field|
        field.include_in_simple_select = false
        field.solr_local_parameters = {
 #         :qf => '$donor_qf',
@@ -625,7 +625,7 @@ end
       }
     end
 
-    config.add_search_field('place of publication_starts',:include_in_advanced_search => false) do |field|
+    config.add_search_field('pubplace_starts', :include_in_advanced_search => false) do |field|
        field.include_in_simple_select = false
        field.solr_local_parameters = {
 #         :qf => '$pubplace_starts_qf',
@@ -655,7 +655,7 @@ end
 #         :pf => '$notes_starts_pf'
        }
     end
-    config.add_search_field('donor name_starts',:include_in_advanced_search => false) do |field|
+    config.add_search_field('donor_starts',:include_in_advanced_search => false) do |field|
        field.include_in_simple_select = false
        field.solr_local_parameters = {
 #         :qf => '$donor_starts_qf',
@@ -731,7 +731,7 @@ end
        }
     end
 
-    config.add_search_field('place of publication_quote',:include_in_advanced_search => false) do |field|
+    config.add_search_field('pubplace_quote',:include_in_advanced_search => false) do |field|
        field.include_in_simple_select = false
        field.solr_local_parameters = {
 #         :qf => '$pubplace_quot_qf',
@@ -761,7 +761,7 @@ end
 #         :pf => '$notes_quot_pf'
        }
     end
-    config.add_search_field('donor name_quote',:include_in_advanced_search => false) do |field|
+    config.add_search_field('donor_quote',:include_in_advanced_search => false) do |field|
        field.include_in_simple_select = false
        field.solr_local_parameters = {
 #         :qf => '$donor_quot_qf',

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -538,7 +538,7 @@ end
        }
     end
 
-    config.add_search_field('donor', :label => 'Donor Name') do |field|
+    config.add_search_field('donor', :label => 'Donor/Provenance') do |field|
        field.include_in_simple_select = false
        field.solr_local_parameters = {
 #         :qf => '$donor_qf',

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -79,7 +79,7 @@ module AdvancedHelper
     subject_values = [["all_fields", "All Fields"],["title", "Title"], ["journal title", "Journal Title"], ["author/creator", "Author, etc."], ["subject", "Subject"],
                       ["call number", "Call Number"], ["series", "Series"], ["publisher", "Publisher"], ["pubplace", "Place Of Publication"],
                       ["publisher number/other identifier", "Publisher Number/Other Identifier"], ["isbn/issn", "ISBN/ISSN"], ["notes", "Notes"],
-                      ["donor", "Donor Name"]]
+                      ["donor", "Donor/Provenance"]]
     boolean_values = [["AND", "all"], ["OR", "any"], ["phrase", "phrase"],["begins_with", "begins with"]]
     boolean_row_values = [["AND", "and"], ["OR", "or"], ["NOT", "not"]]
     word = ""

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -55,11 +55,12 @@ module AdvancedHelper
     end
   end
 
+  DEFAULT_BOOL = 'AND'
   def render_edited_advanced_search(params)
     query = ""
     if params[:boolean_row].nil?
       params[:boolean_row] = [] #{"1"=>"AND"}
-      params[:boolean_row] << "AND"
+      params[:boolean_row] << DEFAULT_BOOL
     end
 
     if params[:q_row].nil?
@@ -128,7 +129,8 @@ module AdvancedHelper
          next2rows << "<div class=\"input_row\"><div class=\"boolean_row radio adv-search-control\">"
          boolean_row_values.each do |key, value|
            n = i - 1 #= i.to_s
-           if key == params[:boolean_row][n]
+           #  Default to "AND" when missing booleans in search params
+           if key == params[:boolean_row][n] || (params[:boolean_row][n].blank? && key == DEFAULT_BOOL)
              next2rows << "<div class=\"form-check form-check-inline\">"
              next2rows << "<label>"
              next2rows << "<input type=\"radio\" name=\"boolean_row[" << "#{i}" << "]\" value=\"" << key << "\" checked=\"checked\">" << " " << value << " "

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -75,10 +75,11 @@ module AdvancedHelper
       params[:search_field_row][0] = 'all_fields'
     end
 
+    # TODO: Set field labels in CatalogController and grab label from search_fields_for_advanced_search?
     subject_values = [["all_fields", "All Fields"],["title", "Title"], ["journal title", "Journal Title"], ["author/creator", "Author, etc."], ["subject", "Subject"],
-                      ["call number", "Call Number"], ["series", "Series"], ["publisher", "Publisher"], ["place of publication", "Place Of Publication"],
+                      ["call number", "Call Number"], ["series", "Series"], ["publisher", "Publisher"], ["pubplace", "Place Of Publication"],
                       ["publisher number/other identifier", "Publisher Number/Other Identifier"], ["isbn/issn", "ISBN/ISSN"], ["notes", "Notes"],
-                      ["donor name", "Donor Name"]]
+                      ["donor", "Donor Name"]]
     boolean_values = [["AND", "all"], ["OR", "any"], ["phrase", "phrase"],["begins_with", "begins with"]]
     boolean_row_values = [["AND", "and"], ["OR", "or"], ["NOT", "not"]]
     word = ""
@@ -120,12 +121,7 @@ module AdvancedHelper
     unless params[:q_row].count <= 1
       next2rows = ""
       for i in 1..params[:q_row].count - 1
-        if params[:q_row][i].include? ' '
-          params[:q_row][i] = "\'" + params[:q_row][i] + "\'"
-        #  query = params[:q_row][0]
-        else
-          params[:q_row][i] = params[:q_row][i]
-        end
+        params[:q_row][i] = "\'" + params[:q_row][i] + "\'"
         # DISCOVERYACCESS-7882 - adv search html injection
         query = ActionView::Base.full_sanitizer.sanitize(params[:q_row][i])
 

--- a/app/helpers/cornell_params_helper.rb
+++ b/app/helpers/cornell_params_helper.rb
@@ -487,9 +487,9 @@ def deep_copy(o)
 end
 
 
-def render_advanced_constraints_query(my_params = params)
-#    if (@advanced_query.nil? || @advanced_query.keyword_queries.empty? )
-
+def render_advanced_constraints_query(params)
+  # Create deep copy of params to not alter original search params hash
+  my_params = params.present? ? params.deep_dup : {}
   if !my_params[:q_row].nil?
      my_params = removeBlanks(my_params)
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1557,6 +1557,10 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   end
 
+  # Default any missing booleans to "AND"
+  # Shouldn't happen unless directly tampering with search params
+  DEFAULT_BOOL = 'AND'
+
   def groupBools(my_params)
      for a in 0..my_params[:q_row].size - 1 do
        if my_params[:q_row][a].include?('journaltitle:') or my_params[:q_row][a].include?('journaltitle_starts')
@@ -1571,23 +1575,21 @@ class SearchBuilder < Blacklight::SearchBuilder
        index = 0
        newstring = ""
        if my_params[:q_row].size > 1
-         #newstring = my_params[:q_row][0]
          for a in 0..my_params[:q_row].size - 1 do
           if a == 0
-                 if my_params[:boolean_row][a] == "NOT"
-                 	newstring = "(" + newstring + my_params[:q_row][a] + ' ' + "-" + my_params[:q_row][a + 1] + ") "
-                 else
-                 	newstring = "(" + newstring + my_params[:q_row][a] + ' ' + my_params[:boolean_row][a] + " " + my_params[:q_row][a + 1] + ") "
-                 end
+            if my_params[:boolean_row][a] == "NOT"
+              newstring = "(" + newstring + my_params[:q_row][a] + ' ' + "-" + my_params[:q_row][a + 1] + ") "
+            else
+              newstring = "(" + newstring + my_params[:q_row][a] + ' ' + (my_params[:boolean_row][a] || DEFAULT_BOOL) + " " + my_params[:q_row][a + 1] + ") "
+            end
           else
             if a < my_params[:q_row].size  and a > 1
-                 if my_params[:boolean_row][a - 1] == "NOT"
-                         newstring = '( ' + newstring + ' ' + '-' + my_params[:q_row][a] + ')'
-                 else
-                         newstring = '( ' + newstring + ' ' + my_params[:boolean_row][a - 1 ] + ' ' + my_params[:q_row][a] + ')'
-                 end
-                a = a + 1
-             #newstring = '(' + my_params[:q_row][index] + ' )' + bool + '( ' + my_params[:q_row][index + 1] + ')'
+              if my_params[:boolean_row][a - 1] == "NOT"
+                newstring = '( ' + newstring + ' ' + '-' + my_params[:q_row][a] + ')'
+              else
+                newstring = '( ' + newstring + ' ' + (my_params[:boolean_row][a - 1] || DEFAULT_BOOL) + ' ' + my_params[:q_row][a] + ')'
+              end
+              a = a + 1
             end
            end
            a = 1

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1212,17 +1212,11 @@ class SearchBuilder < Blacklight::SearchBuilder
       if sfr == "call number"
         sfr = "lc_callnum"
       end
-      if sfr == "place of publication"
-        sfr = "pubplace"
-      end
       if sfr == "publisher number/other identifier"
         sfr = "number"
       end
       if sfr == "isbn/issn"
         sfr = "isbnissn"
-      end
-      if sfr == "donor name"
-        sfr = "donor"
       end
       if sfr == "journal title"
         sfr = "journaltitle"
@@ -1276,17 +1270,11 @@ class SearchBuilder < Blacklight::SearchBuilder
                 if solr_stuff == "call number"
                   solr_stuff = "lc_callnum"
                 end
-                if solr_stuff == "place of publication"
-                  solr_stuff = "pubplace"
-                end
                 if solr_stuff == "publisher number/other identifier"
                   solr_stuff = "number"
                 end
                 if solr_stuff == "isbn/issn"
                   solr_stuff = "isbnissn"
-                end
-                if solr_stuff == "donor name"
-                  solr_stuff = "donor"
                 end
                 if solr_stuff == "journal title"
                   my_params[:f] = {}

--- a/features/catalog_search/advanced_search.feature
+++ b/features/catalog_search/advanced_search.feature
@@ -21,7 +21,8 @@ Feature: Search
     Then the 'search_field_advanced' drop-down should have an option for 'Publisher'
     Then the 'search_field_advanced' drop-down should have an option for 'Subject'
     Then the 'search_field_advanced' drop-down should have an option for 'Series'
-    Then the 'search_field_advanced' drop-down should have an option for 'Donor'
+    Then the 'search_field_advanced' drop-down should have an option for 'Place of Publication'
+    Then the 'search_field_advanced' drop-down should have an option for 'Donor Name'
     #Then the 'boolean_row[1]' radio should have an option for 'or'
 
   @adv_search
@@ -260,8 +261,10 @@ Feature: Search
     And I select 'Donor Name' from the 'search_field_advanced' drop-down
     And I press 'advanced_search'
     Then I should get 2 results
-    #And I should see the label '1 result'
-    #And I should not see the label 'Modify advanced'
+    And click on first link "The annual of the British school at Athens"
+    Then I should see the label 'The annual of the British school at Athens'
+    Then click on first link "Back to catalog results"
+    And I should get 2 results
 
 #
  @adv_search
@@ -380,6 +383,23 @@ Feature: Search
     Then I should get results
     And I should see the label '1 result'
     And I should see the label 'Modify advanced'
+
+  @adv_search
+  @all_search
+  @adv_place
+  @javascript
+  Scenario: Perform an advanced search by place of publication
+    When I literally go to advanced
+    And I sleep 4 seconds
+    And I fill in "q_row1" with 'New York'
+    And I select 'all' from the 'op_row' drop-down
+    And I select 'Place of Publication' from the 'search_field_advanced' drop-down
+    And I press 'advanced_search'
+    Then I should get 41 results
+    And click on first link "The basic practice of statistics"
+    Then I should see the label 'The basic practice of statistics'
+    Then click on first link "Back to catalog results"
+    And I should get 41 results
 
  @begins_with
  @adv_search

--- a/features/catalog_search/advanced_search.feature
+++ b/features/catalog_search/advanced_search.feature
@@ -22,7 +22,7 @@ Feature: Search
     Then the 'search_field_advanced' drop-down should have an option for 'Subject'
     Then the 'search_field_advanced' drop-down should have an option for 'Series'
     Then the 'search_field_advanced' drop-down should have an option for 'Place of Publication'
-    Then the 'search_field_advanced' drop-down should have an option for 'Donor Name'
+    Then the 'search_field_advanced' drop-down should have an option for 'Donor/Provenance'
     #Then the 'boolean_row[1]' radio should have an option for 'or'
 
   @adv_search
@@ -258,7 +258,7 @@ Feature: Search
     When I literally go to advanced
     And I fill in "q_row1" with 'Class of 1957'
     And I select 'all' from the 'op_row' drop-down
-    And I select 'Donor Name' from the 'search_field_advanced' drop-down
+    And I select 'Donor/Provenance' from the 'search_field_advanced' drop-down
     And I press 'advanced_search'
     Then I should get 2 results
     And click on first link "The annual of the British school at Athens"
@@ -275,10 +275,10 @@ Feature: Search
     When I literally go to advanced
     And I fill in "q_row1" with '1957'
     And I select 'all' from the 'op_row' drop-down
-    And I select 'Donor Name' from the 'search_field_advanced' drop-down
+    And I select 'Donor/Provenance' from the 'search_field_advanced' drop-down
     And I fill in "q_row2" with 'Pumpelly'
     And I select 'all' from the 'op_row2' drop-down
-    And I select 'Donor Name' from the 'search_field_advanced2' drop-down
+    And I select 'Donor/Provenance' from the 'search_field_advanced2' drop-down
     And I press 'advanced_search'
     Then I should get results
     And I should see the label '1 result'

--- a/features/catalog_search/advanced_search.feature
+++ b/features/catalog_search/advanced_search.feature
@@ -201,8 +201,12 @@ Feature: Search
     And I select 'phrase' from the 'op_row' drop-down
     And I select 'Notes' from the 'search_field_advanced' drop-down
     And I press 'advanced_search'
-    Then I should get results
-    And I should see the label '1 result'
+    Then I should get 1 results
+    And I should see the "Notes" facet constraint
+    And click on first link "Annulus wall boundary layers in turbomachines"
+    Then I should see the label 'Annulus wall boundary layers in turbomachines'
+    And click on first link "Back to catalog results"
+    Then I should get 1 results
 
 # purple rain: music
  @adv_search
@@ -261,10 +265,11 @@ Feature: Search
     And I select 'Donor/Provenance' from the 'search_field_advanced' drop-down
     And I press 'advanced_search'
     Then I should get 2 results
+    And I should see the "Donor/Provenance" facet constraint
     And click on first link "The annual of the British school at Athens"
     Then I should see the label 'The annual of the British school at Athens'
-    Then click on first link "Back to catalog results"
-    And I should get 2 results
+    And click on first link "Back to catalog results"
+    Then I should get 2 results
 
 #
  @adv_search
@@ -396,6 +401,7 @@ Feature: Search
     And I select 'Place of Publication' from the 'search_field_advanced' drop-down
     And I press 'advanced_search'
     Then I should get 41 results
+    And I should see the "Place of Publication" facet constraint
     And click on first link "The basic practice of statistics"
     Then I should see the label 'The basic practice of statistics'
     Then click on first link "Back to catalog results"

--- a/features/step_definitions/catalog_search_steps.rb
+++ b/features/step_definitions/catalog_search_steps.rb
@@ -173,6 +173,10 @@ Then("I remove facet constraint {string}") do |string|
   page.find(".selected-facets .filter-value", text: string).click
 end
 
+Then("I should see the {string} facet constraint") do |facet_label|
+  page.should have_selector(".selected-facets .filter-label", text: facet_label)
+end
+
 Then("I should see only the first {int} Format facets") do |int|
   items = page.all('div#facet-format ul.facet-values > li')
   if items.count > 10

--- a/spec/helpers/advanced_helper_spec.rb
+++ b/spec/helpers/advanced_helper_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe AdvancedHelper, type: :helper do
+  let(:params_missing_bools) {
+    {
+      q_row: ["curly", "moe", "larry"],
+      controller: "advanced_search",
+      action: "edit",
+      advanced_query: "yes"
+    }
+  }
+
+  describe '#render_edited_advanced_search' do
+    it 'defaults to selecting the "AND" boolean when boolean_row is missing' do
+      edited_advanced_search = helper.render_edited_advanced_search(params_missing_bools)
+      expect(edited_advanced_search).to include('name="boolean_row[1]" value="AND" checked="checked"')
+      expect(edited_advanced_search).to include('name="boolean_row[2]" value="AND" checked="checked"')
+    end
+  end
+end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SearchBuilder, type: :model do
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:scope) { double blacklight_config: blacklight_config }
+  subject(:search_builder) { described_class.new scope }
+
+  describe '#groupBools' do
+    let(:params) {
+      {
+        q_row: ['curly', 'moe', 'larry'],
+        boolean_row: ['AND', 'OR']
+      }
+    }
+
+    it 'returns queries chained by expected booleans' do
+      expect(search_builder.groupBools(params)).to eq('( (curly AND moe)  OR larry)')
+    end
+
+    context 'missing booleans' do
+      let(:params) {
+        {
+          q_row: ['curly', 'moe', 'larry'],
+          boolean_row: ['AND']
+        }
+      }
+
+      it 'defaults missing booleans to "AND"' do
+        expect(search_builder.groupBools(params)).to eq('( (curly AND moe)  AND larry)')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Jira:

- [DISCOVERYACCESS-8118: Paging through the records returned from a donor search breaks the search](https://culibrary.atlassian.net/browse/DISCOVERYACCESS-8118)
  - Also found to be an issue for phrase searching and for place of publication searches
- [DISCOVERYACCESS-8127: Notes advanced search results can become fuzzy after viewing an item and returning to results](https://culibrary.atlassian.net/browse/DISCOVERYACCESS-8127)
- [DISCOVERYACCESS-643: Reconsider labeling of "Donor name" field on advanced search](https://culibrary.atlassian.net/browse/DISCOVERYACCESS-643)
  - Melissa recommended changing to "Donor/Provenance"
- [DISCOVERYACCESS-7910: Advanced search chokes on missing booleans](https://culibrary.atlassian.net/browse/DISCOVERYACCESS-7910)
  - Arguably, this should continue to result in 500 errors, but added some default handling anyway. Defaulted to "AND" boolean because this is the default selected bool on a new advanced search form.

Changes:

- Remove logic that secretly altered search session params in the `link_back_to_catalog` method. I'm not sure why it was there - nothing seems to have newly broken, but it fixed both 8118 and 8127...
- Switched to using `deep_dup` instead of `dup` when trying to copy the params hash in `render_advanced_constraints_query`, so that any changes to the copied hash would not also incorrectly update the original hash (deep copy instead of shallow copy). This fixed an error where constraint filters were not displaying on the advanced search results page.
- Renamed "Donor Name" search filter label to "Donor/Provenance" in Advanced Search
- Set boolean operator to "and" by default when booleans are missing in search url params