### PR TITLE
DISCOVERYACCESS-8206: fix padding around previous/next links in facet…

### DIFF
--- a/app/assets/stylesheets/cornell/_bookmarks.scss
+++ b/app/assets/stylesheets/cornell/_bookmarks.scss
@@ -64,17 +64,16 @@
   background: none;
   border: none;
   text-decoration: underline;
-  padding: 0;
   .fa {
   	margin-right: .25rem;
   }
-  // padding: 0!important;
-  // /*optional*/
-  // font-family: arial, sans-serif;
-  // /*input has OS specific font-family*/
-  // color: #069;
-  // text-decoration: underline;
-  // cursor: pointer;
+}
+
+// DISCOVERYACCESS-8206: be more explicit about where to remove the padding from btn-link because it messes up the alignment of previous/next buttons in modal facets
+.blacklight-nav {
+	.btn-link {
+		padding: 0;
+	}
 }
 
 // MEDIA QUERIES


### PR DESCRIPTION
… modal

It looks like I removed some padding from the btn-link class when doing some work on the 'sign in' link. I added some specificity to the padding rule so that it should only affect btn-link in the blacklight-nav element.