### PR TITLE
DACCESS-203 - Pre-populate advanced edit form with selected booleans

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -32,8 +32,7 @@ module AdvancedHelper
   def render_edited_advanced_search(params)
     query = ""
     if params[:boolean_row].nil?
-      params[:boolean_row] = [] #{"1"=>"AND"}
-      params[:boolean_row] << DEFAULT_BOOL
+      params[:boolean_row] = { '1' => DEFAULT_BOOL }
     end
 
     if params[:q_row].nil?
@@ -101,7 +100,7 @@ module AdvancedHelper
 
          next2rows << "<div class=\"input_row\"><div class=\"boolean_row radio adv-search-control\">"
          boolean_row_values.each do |key, value|
-           n = i - 1 #= i.to_s
+           n = i.to_s
            #  Default to "AND" when missing booleans in search params
            if key == params[:boolean_row][n] || (params[:boolean_row][n].blank? && key == DEFAULT_BOOL)
              next2rows << "<div class=\"form-check form-check-inline\">"
@@ -146,20 +145,19 @@ module AdvancedHelper
       next2rows = ""
       next2rows << "<div class=\"input_row\"><div class=\"boolean_row radio adv-search-control\">"
       boolean_row_values.each do |key, value|
-           if params[:boolean_row][1].blank?
-             params[:boolean_row][1] = "AND"
+           if params[:boolean_row]['1'].blank?
+             params[:boolean_row]['1'] = "AND"
            end
-           n = 1.to_s
-           if key == params[:boolean_row][1]
+           if key == params[:boolean_row]['1']
              next2rows << "<div class=\"form-check form-check-inline\">"
              next2rows << "<label>"
-             next2rows << "<input type=\"radio\" name=\"boolean_row[" << "#{1}" << "]\" value=\"" << key << "\" checked=\"checked\">" << " " << value << " "
+             next2rows << "<input type=\"radio\" name=\"boolean_row[1]\" value=\"" << key << "\" checked=\"checked\">" << " " << value << " "
              next2rows << "</label>"
              next2rows << "</div>"
            else
              next2rows << "<div class=\"form-check form-check-inline\">"
              next2rows << "<label>"
-             next2rows << "<input type=\"radio\" name=\"boolean_row[" << "#{1}" << "]\" value=\"" << key << "\">" << " " << value << " "
+             next2rows << "<input type=\"radio\" name=\"boolean_row[1]\" value=\"" << key << "\">" << " " << value << " "
              next2rows << "</label>"
              next2rows << "</div>"
            end

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -48,11 +48,7 @@ module AdvancedHelper
       params[:search_field_row][0] = 'all_fields'
     end
 
-    # TODO: Set field labels in CatalogController and grab label from search_fields_for_advanced_search?
-    subject_values = [["all_fields", "All Fields"],["title", "Title"], ["journaltitle", "Journal Title"], ["author", "Author, etc."], ["subject", "Subject"],
-                      ["lc_callnum", "Call Number"], ["series", "Series"], ["publisher", "Publisher"], ["pubplace", "Place Of Publication"],
-                      ["number", "Publisher Number/Other Identifier"], ["isbnissn", "ISBN/ISSN"], ["notes", "Notes"],
-                      ["donor", "Donor/Provenance"]]
+    subject_values = blacklight_config.search_fields.reject { |k, v| v.include_in_advanced_search == false }
     boolean_values = [["AND", "all"], ["OR", "any"], ["phrase", "phrase"],["begins_with", "begins with"]]
     boolean_row_values = [["AND", "and"], ["OR", "or"], ["NOT", "not"]]
     word = ""
@@ -85,9 +81,9 @@ module AdvancedHelper
     row1 << "<select class=\"advanced-search-field form-control adv-search-control\" id=\"search_field_row\" name=\"search_field_row[]\">"
     subject_values.each do |key, value|
       if key == params[:search_field_row][0]
-        row1 << "<option value=\"" << key << "\" selected>" << value << "</option>"
+        row1 << "<option value=\"" << key << "\" selected>" << value.label << "</option>"
       else
-        row1 << "<option value=\"" << key << "\">" << value << "</option>"
+        row1 << "<option value=\"" << key << "\">" << value.label << "</option>"
       end
     end
     row1 << "</select>"
@@ -134,9 +130,9 @@ module AdvancedHelper
          next2rows << "<select class=\"advanced-search-field form-control adv-search-control\" id=\"search_field_row" << "#{i}" << "\" name=\"search_field_row[]\">"
          subject_values.each do |key, value|
            if key == params[:search_field_row][i]
-            next2rows << "<option value=\"" << key << "\" selected>" << value << "</option>"
+            next2rows << "<option value=\"" << key << "\" selected>" << value.label << "</option>"
            else
-             next2rows << "<option value=\"" << key << "\">" << value << "</option>"
+             next2rows << "<option value=\"" << key << "\">" << value.label << "</option>"
            end
          end
           next2rows << "</select></div></div>"
@@ -178,9 +174,9 @@ module AdvancedHelper
     next2rows << "<select class=\"advanced-search-field form-control adv-search-control\" id=\"search_field_row\" name=\"search_field_row[]\">"
     subject_values.each do |key, value|
       if key == params[:search_field_row][0]
-        next2rows << "<option value=\"" << key << "\" selected>" << value << "</option>"
+        next2rows << "<option value=\"" << key << "\" selected>" << value.label << "</option>"
       else
-        next2rows << "<option value=\"" << key << "\">" << value << "</option>"
+        next2rows << "<option value=\"" << key << "\">" << value.label << "</option>"
       end
     end
 

--- a/features/security/injection.feature
+++ b/features/security/injection.feature
@@ -12,4 +12,4 @@ Examples:
 | hack | output |
 | /edit?q_row[]=test%3E%3Cb%3Ethis-is-html%3C/b%3E | this-is-html |
 | /edit?q_row%5b%5d=test%3E%3Cb%3EINJECT-ME%3C/b%3E | INJECT-ME |
-| /edit?boolean_row[]=AND&boolean_row[]=AND&op_row[]=AND&op_row[]=AND&op_row[]=AND&q_row[]=test%3E%3Cb%3EINJECT-ME%3C/b%3E&q_row[]=test%3E%3Cb%3EINJECT-ME%3C/b%3E&q_row[]=test%3E%3Cb%3EINJECT-ME%3C/b%3E&search_field_row[]=all_fields&search_field_row[]=all_fields&search_field_row[]=all_fields | INJECT-ME |
+| /edit?boolean_row[1]=AND&boolean_row[2]=AND&op_row[]=AND&op_row[]=AND&op_row[]=AND&q_row[]=test%3E%3Cb%3EINJECT-ME%3C/b%3E&q_row[]=test%3E%3Cb%3EINJECT-ME%3C/b%3E&q_row[]=test%3E%3Cb%3EINJECT-ME%3C/b%3E&search_field_row[]=all_fields&search_field_row[]=all_fields&search_field_row[]=all_fields | INJECT-ME |

--- a/spec/helpers/advanced_helper_spec.rb
+++ b/spec/helpers/advanced_helper_spec.rb
@@ -1,20 +1,58 @@
 require "rails_helper"
 
 RSpec.describe AdvancedHelper, type: :helper do
-  let(:params_missing_bools) {
-    {
-      q_row: ["curly", "moe", "larry"],
-      controller: "advanced_search",
-      action: "edit",
-      advanced_query: "yes"
-    }
-  }
-
   describe '#render_edited_advanced_search' do
-    it 'defaults to selecting the "AND" boolean when boolean_row is missing' do
-      edited_advanced_search = helper.render_edited_advanced_search(params_missing_bools)
-      expect(edited_advanced_search).to include('name="boolean_row[1]" value="AND" checked="checked"')
-      expect(edited_advanced_search).to include('name="boolean_row[2]" value="AND" checked="checked"')
+    let(:edited_advanced_search) { helper.render_edited_advanced_search(params) }
+
+    context 'non-default operators and booleans selected' do
+      let(:params) { {
+        q_row: ['Severus', 'Lily', 'Boyface Killah', 'English Breakfast'],
+        op_row: ['AND', 'OR', 'begins_with', 'phrase'],
+        boolean_row: { '1' => 'OR', '2' => 'AND', '3' => 'NOT' },
+        search_field_row: ['author', 'title', 'subject', 'series'],
+        controller: 'advanced_search',
+        action: 'edit',
+        advanced_query: 'yes'
+      } }
+
+      it 'pre-fills previously selected values' do
+        # boolean_row
+        expect(edited_advanced_search).to include('name="boolean_row[1]" value="OR" checked="checked"')
+        expect(edited_advanced_search).to include('name="boolean_row[2]" value="AND" checked="checked"')
+        expect(edited_advanced_search).to include('name="boolean_row[3]" value="NOT" checked="checked"')
+
+        # q_row
+        expect(edited_advanced_search).to match(/input[^>]+id="q_row"[^>]+value=Severus/)
+        expect(edited_advanced_search).to match(/input[^>]+id="q_row1"[^>]+value='Lily'/)
+        expect(edited_advanced_search).to match(/input[^>]+id="q_row2"[^>]+value='Boyface Killah'/)
+        expect(edited_advanced_search).to match(/input[^>]+id="q_row3"[^>]+value='English Breakfast'/)
+
+        # op_row
+        expect(edited_advanced_search).to match(/id="op_row".+option value="AND" selected/)
+        expect(edited_advanced_search).to match(/id="op_row1".+option value="OR" selected/)
+        expect(edited_advanced_search).to match(/id="op_row2".+option value="begins_with" selected/)
+        expect(edited_advanced_search).to match(/id="op_row3".+option value="phrase" selected/)
+
+        # search_field_row
+        expect(edited_advanced_search).to match(/id="search_field_row".+option value="author" selected/)
+        expect(edited_advanced_search).to match(/id="search_field_row1".+option value="title" selected/)
+        expect(edited_advanced_search).to match(/id="search_field_row2".+option value="subject" selected/)
+        expect(edited_advanced_search).to match(/id="search_field_row3".+option value="series" selected/)
+      end
+    end
+
+    context 'boolean_row is missing' do
+      let(:params) { {
+        q_row: ['curly', 'moe', 'larry'],
+        controller: 'advanced_search',
+        action: 'edit',
+        advanced_query: 'yes'
+      } }
+
+      it 'defaults to selecting the "AND" boolean when boolean_row is missing' do
+        expect(edited_advanced_search).to include('name="boolean_row[1]" value="AND" checked="checked"')
+        expect(edited_advanced_search).to include('name="boolean_row[2]" value="AND" checked="checked"')
+      end
     end
   end
 end

--- a/spec/helpers/advanced_helper_spec.rb
+++ b/spec/helpers/advanced_helper_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe AdvancedHelper, type: :helper do
   describe '#render_edited_advanced_search' do
     let(:edited_advanced_search) { helper.render_edited_advanced_search(params) }
 
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
+      end
+    end
+
     context 'non-default operators and booleans selected' do
       let(:params) { {
         q_row: ['Severus', 'Lily', 'Boyface Killah', 'English Breakfast'],


### PR DESCRIPTION
Fixes: https://culibrary.atlassian.net/browse/DACCESS-203

Also address a TODO I'd added a few months back re: logic that displays the search field dropdown.

This PR is chained off of these other 2 related PRs:
- https://github.com/cul-it/blacklight-cornell/pull/2078
- https://github.com/cul-it/blacklight-cornell/pull/2079