### PR TITLE
DACCESS-293 - enable testing individual branches on individual cucumber tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@
 .
 ├── blacklight-cornell
 ├── docker
-│   └── bookworm
-│       └── Dockerfile
+│   └── bookworm
+│       └── Dockerfile
 ├── docker-compose-cred.yaml
 ├── docker-compose-development.yaml
 ├── docker-compose-test-interactive.yaml
 ├── docker-compose-test.yaml
 ├── docker-compose.yaml
 ├── exe
-│   ├── get_env.rb
-│   ├── puma.rb
-│   ├── puma.sh
-│   ├── set_env.sh
-│   └── test.sh
+│   ├── get_env.rb
+│   ├── puma.rb
+│   ├── puma.sh
+│   ├── set_env.sh
+│   └── test.sh
 ├── rails_env
-│   └── test.env.example
+│   └── test.env.example
 ├── CHANGELOG.md
 ├── LICENSE
 ├── README.md

--- a/blacklight-cornell/app/views/advanced_search/_advanced_search_tips.html.erb
+++ b/blacklight-cornell/app/views/advanced_search/_advanced_search_tips.html.erb
@@ -17,7 +17,7 @@
     <dt><strong>and</strong></dt>
     <dd>Retrieves items that contain the terms from both rows.</dd>
     <dt><strong>or</strong></dt>
-    <dd>Retrieves items  that contain the terms from either row.</dd>
+    <dd>Retrieves items that contain the terms from either row.</dd>
     <dt><strong>not</strong></dt>
     <dd>Retrieves items that specifically don't include the terms from this row.</dd>
   </dl>

--- a/blacklight-cornell/config/environments/test.rb
+++ b/blacklight-cornell/config/environments/test.rb
@@ -57,4 +57,7 @@ BlacklightCornell::Application.configure do
   # this allows WEBrick to handle pipe symbols in query parameters
 #URI::DEFAULT_PARSER = URI::Parser.new(:UNRESERVED => URI::REGEXP::PATTERN::UNRESERVED + '|')
 
+  # suppress deprecation warnings
+  Deprecation.default_deprecation_behavior = :silence # :stderr # :silence
+
 end

--- a/blacklight-cornell/config/environments/test.rb
+++ b/blacklight-cornell/config/environments/test.rb
@@ -28,7 +28,7 @@ BlacklightCornell::Application.configure do
   }
 
   # Print deprecation notices to the Rails logger
-  config.active_support.deprecation = :silence
+  config.active_support.deprecation = :log
   # See everything in the log (default is :info)
  #config.log_level = ENV["LOG_LEVEL"].blank?  ? :debug : ENV["LOG_LEVEL"].to_sym
  config.log_level = ENV["LOG_LEVEL"].blank?  ? :debug : ENV["LOG_LEVEL"].to_sym

--- a/blacklight-cornell/config/environments/test.rb
+++ b/blacklight-cornell/config/environments/test.rb
@@ -28,7 +28,7 @@ BlacklightCornell::Application.configure do
   }
 
   # Print deprecation notices to the Rails logger
-  config.active_support.deprecation = :log
+  config.active_support.deprecation = :silence
   # See everything in the log (default is :info)
  #config.log_level = ENV["LOG_LEVEL"].blank?  ? :debug : ENV["LOG_LEVEL"].to_sym
  config.log_level = ENV["LOG_LEVEL"].blank?  ? :debug : ENV["LOG_LEVEL"].to_sym

--- a/jenkins/cucumber-features.sh
+++ b/jenkins/cucumber-features.sh
@@ -14,11 +14,11 @@ OPT2="-t ~@search_availability_title_mission_etrangeres_missing "
 OPT4=" -t ~@saml_off "
 export COVERAGE=on
 export RAILS_ENV=test
-if [ $# -eq 0 ]
+if [ -z ${CUCUMBER_FEATURE_TESTS+x} ]
     then
         echo "Running all feature tests."
         bundle exec cucumber $OPT1 $OPT2 $OPT3 $OPT4
     else
-        echo "Running feature: $1"
-        bundle exec cucumber $OPT1 $OPT2 $OPT3 $OPT4 "$1"
+        echo "Running feature: ${CUCUMBER_FEATURE_TESTS}"
+        bundle exec cucumber $OPT1 $OPT2 $OPT3 $OPT4 "${CUCUMBER_FEATURE_TESTS}"
 fi

--- a/jenkins/environment.sh
+++ b/jenkins/environment.sh
@@ -42,4 +42,4 @@ which bundle
 chromedriver --version
 echo "Xvfb DISPLAY value is $DISPLAY"
 echo "Diligent Tester: $DEBUG_USER"
-grep ^SOLR_URL .env
+grep ^SOLR_URL blacklight-cornell/.env


### PR DESCRIPTION
Replaced the old version https://awsjenkins.library.cornell.edu/view/blacklight/job/blacklight-cornell-branch-testing-folio/ with a version that will work on the container branch:

https://awsjenkins.library.cornell.edu/view/blacklight/job/container-branch-testing/