### PR TITLE
Downgrade SAML

### DIFF
--- a/blacklight-cornell/Gemfile
+++ b/blacklight-cornell/Gemfile
@@ -127,7 +127,7 @@ gem 'blacklight_cornell_requests', :git =>'https://github.com/cul-it/blacklight-
 gem 'cul-folio-edge', :git => 'https://github.com/cul-it/cul-folio-edge', tag: 'v3.0'
 gem 'my_account', :git => 'https://github.com/cul-it/cul-my-account'
 gem 'borrow_direct', :git => 'https://github.com/jrochkind/borrow_direct'
-gem 'ruby-saml', '>= 1.12.1'
+gem 'ruby-saml', '1.15'
 gem 'bento_search', '~> 2.0.0.rc1'
 gem 'celluloid', '0.17.4' # Required for bento_search multisearcher
 gem 'exception_notification'

--- a/blacklight-cornell/Gemfile.lock
+++ b/blacklight-cornell/Gemfile.lock
@@ -694,7 +694,7 @@ GEM
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby-plsql (0.8.0)
-    ruby-saml (1.16.0)
+    ruby-saml (1.15.0)
       nokogiri (>= 1.13.10)
       rexml
     ruby2_keywords (0.0.5)
@@ -924,7 +924,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rspec_junit_formatter
-  ruby-saml (>= 1.12.1)
+  ruby-saml (= 1.15)
   rufus-scheduler
   sass-rails (~> 5.0)
   sassc (~> 2.4)

--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -1160,6 +1160,7 @@ def tou
         if attrs["isSelected"] == true
           packageID = attrs["packageId"]
           packageName = attrs["packageName"]
+
           # packageUrl = attrs["url"]
           # package_providerID = attrs["providerName"]
           subscription = subscription_agreements(packageID)
@@ -1183,7 +1184,7 @@ def tou
   def eholdings_record(id)
     # eholdings title JSON response described here:
     # https://s3.amazonaws.com/foliodocs/api/mod-kb-ebsco-java/r/titles.html#eholdings_titles_get
-    folio_request("#{ENV['OKAPI_URL']}/eholdings/titles/#{id}?include=resources")
+    folio_request("#{ENV['OKAPI_URL']}/eholdings/titles/#{id}?include=resources", 'application/vnd.api+json')
   end
 
   # Make a FOLIO request to retrieve an array of subscription agreements linked to an e-holdings record
@@ -1199,13 +1200,14 @@ def tou
   end
 
   # Given a URL, make a FOLIO request and return the results (or nil in case of a RestClient exception).
-  def folio_request(url)
+  # For reasons unknown, some API calls require different accept headers for their JSON, so we need to specify it (sometimes).
+  def folio_request(url, accept_header = 'application/json')
     token = folio_token
     if url && token
       headers = {
         'X-Okapi-Tenant' => ENV['TENANT_ID'],
         'x-okapi-token' => token,
-        :accept => 'application/vnd.api+json'
+        :accept => accept_header
       }
       response = RestClient.get(url, headers)
       JSON.parse(response.body) if response && response.code == 200

--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -1184,7 +1184,7 @@ def tou
   def eholdings_record(id)
     # eholdings title JSON response described here:
     # https://s3.amazonaws.com/foliodocs/api/mod-kb-ebsco-java/r/titles.html#eholdings_titles_get
-    folio_request("#{ENV['OKAPI_URL']}/eholdings/titles/#{id}?include=resources", 'application/vnd.api+json')
+    folio_request("#{ENV['OKAPI_URL']}/eholdings/titles/#{id}?include=resources")
   end
 
   # Make a FOLIO request to retrieve an array of subscription agreements linked to an e-holdings record
@@ -1200,14 +1200,13 @@ def tou
   end
 
   # Given a URL, make a FOLIO request and return the results (or nil in case of a RestClient exception).
-  # For reasons unknown, some API calls require different accept headers for their JSON, so we need to specify it (sometimes).
-  def folio_request(url, accept_header = 'application/json')
+  def folio_request(url)
     token = folio_token
     if url && token
       headers = {
         'X-Okapi-Tenant' => ENV['TENANT_ID'],
         'x-okapi-token' => token,
-        :accept => accept_header
+        :accept => 'application/json, application/vnd.api+json'
       }
       response = RestClient.get(url, headers)
       JSON.parse(response.body) if response && response.code == 200


### PR DESCRIPTION
It looks as though an update of ruby-saml to v1.16 may have broken the SAML authentication on our site. This is a downgrade to the previous version in the hope that that will fix this issue. 

This also includes a fix for an unrelated issue wherein the ERM API response headers have changed and broken the TOU lookup.