### PR TITLE
DACCESS-311 - return to longer capybara timeout

### DIFF
--- a/blacklight-cornell/features/support/selenium.rb
+++ b/blacklight-cornell/features/support/selenium.rb
@@ -16,8 +16,7 @@ if ENV['USE_TEST_CONTAINER']
     config.server = :webrick # :puma, { Silent: true }
     config.server_host = webapp_host
     config.server_port = webapp_port
-    # config.default_max_wait_time = 10
-    config.default_max_wait_time = 5
+    config.default_max_wait_time = 10
   end
 
   require 'selenium/webdriver'


### PR DESCRIPTION
 Net::ReadTimeout with #<TCPSocket:(closed)> (Net::ReadTimeout)
      ./features/step_definitions/domain_steps.rb:17:in `do_visit'
      ./features/step_definitions/catalog_search_steps.rb:149:in `"I sign in to BookBag"'
      features/catalog_search/book_bags.feature:12:in `And I sign in to BookBag'