### PR TITLE
DACCESS-313 - re-add test that was temporarily removed

### DIFF
--- a/blacklight-cornell/features/single_search/results_list.feature
+++ b/blacklight-cornell/features/single_search/results_list.feature
@@ -210,10 +210,7 @@ Scenario Outline: Search within Portal results for each collection
   And I press 'Search'
   And I sleep 2 seconds
   Then I should get Digital Collections results
-  And when I view all Digital Collections Items
-  And I sleep 2 seconds
-  Then where am I
-  Then I should see the text "<item>"
+  Then Digital Collections should list "<item>"
 
 Examples:
   | query | item |

--- a/blacklight-cornell/features/single_search/results_list.feature
+++ b/blacklight-cornell/features/single_search/results_list.feature
@@ -204,23 +204,23 @@ Feature: Results list
 
 # Digital Collections Portal search
 # @all_results_list @dcp_search
-# Scenario Outline: Search within Portal results for each collection
-#   Given I literally go to search
-#   When I fill in "q" with '<query>'
-#   And I press 'Search'
-#   And I sleep 2 seconds
-#   Then I should get Digital Collections results
-#   And when I view all Digital Collections Items
-#   And I sleep 2 seconds
-#   Then where am I
-#   Then I should see the text "<item>"
+Scenario Outline: Search within Portal results for each collection
+  Given I literally go to search
+  When I fill in "q" with '<query>'
+  And I press 'Search'
+  And I sleep 2 seconds
+  Then I should get Digital Collections results
+  And when I view all Digital Collections Items
+  And I sleep 2 seconds
+  Then where am I
+  Then I should see the text "<item>"
 
-# Examples:
-#   | query | item |
-#   | iceland highest trees | The highest trees in Iceland. Birch 29 feet high |
-#   | wooden nutmeg | blasphemy of abolitionism exposed |
-#   | work bench | Tompkins County Work Bench in Cellar |
-#   | penitentiary | Society for the Alleviation of the Miseries |
+Examples:
+  | query | item |
+  | iceland highest trees | The highest trees in Iceland. Birch 29 feet high |
+  | wooden nutmeg | blasphemy of abolitionism exposed |
+  | work bench | Tompkins County Work Bench in Cellar |
+  | penitentiary | Society for the Alleviation of the Miseries |
 
 # Institutional Repository search
 @all_results_list @ir_search

--- a/blacklight-cornell/features/step_definitions/web_steps.rb
+++ b/blacklight-cornell/features/step_definitions/web_steps.rb
@@ -238,7 +238,7 @@ end
 
 Then("where am I") do
   puts "\n********************* where am I V\n"
-  puts URI.parse(current_url).path
+  where_am_i
   puts "\n********************* where am I ^\n"
 end
 

--- a/blacklight-cornell/features/support/selenium.rb
+++ b/blacklight-cornell/features/support/selenium.rb
@@ -16,8 +16,7 @@ if ENV['USE_TEST_CONTAINER']
     config.server = :webrick # :puma, { Silent: true }
     config.server_host = webapp_host
     config.server_port = webapp_port
-    # config.default_max_wait_time = 10
-    config.default_max_wait_time = 5
+    config.default_max_wait_time = 10
   end
 
   require 'selenium/webdriver'


### PR DESCRIPTION
- increase default wait time for cucumber
- Simplified version of blacklight-cornell/features/single_search/results_list.feature:207
- uncommented test blacklight-cornell/features/single_search/results_list.feature:207