### PR TITLE
Pin my_account gem to 2.2.5 to fix v2.3 gemspec error

### DIFF
--- a/blacklight-cornell/Gemfile
+++ b/blacklight-cornell/Gemfile
@@ -125,7 +125,7 @@ gem "blacklight_cornell_requests", :git => "https://github.com/cul-it/blacklight
 # gem 'blacklight_cornell_requests', :path => '/Users/matt/code/cul/d&a/blacklight-cornell-requests'
 # gem 'my_account', :path => '/Users/matt/code/cul/d&a/cul-my-account'
 gem "cul-folio-edge", :git => "https://github.com/cul-it/cul-folio-edge", :tag => "v3.0"
-gem "my_account", :git => "https://github.com/cul-it/cul-my-account"
+gem "my_account", :git => "https://github.com/cul-it/cul-my-account", :tag => "v2.2.5"
 gem "borrow_direct", :git => "https://github.com/jrochkind/borrow_direct"
 gem "ruby-saml", ">= 1.12.1"
 gem "bento_search", "~> 2.0.0.rc1"

--- a/blacklight-cornell/Gemfile.lock
+++ b/blacklight-cornell/Gemfile.lock
@@ -49,6 +49,7 @@ GIT
 GIT
   remote: https://github.com/cul-it/cul-my-account
   revision: cf1a5866a6be40e7244ff16e6641495d4d5bb017
+  tag: v2.2.5
   specs:
     my_account (2.2.5)
       blacklight (>= 7.0)


### PR DESCRIPTION
To fix error on jenkins in blacklight-cornell-validate-pull-request-mb job:

```
[!] There was an error while loading `my_account.gemspec`: Illformed requirement ["~3.1"]. Bundler cannot continue.

 #  from /usr/local/rvm/gems/ruby-3.2.2/bundler/gems/cul-my-account-0cea3d4928ed/my_account.gemspec:24
 #  -------------------------------------------
 #    s.add_dependency 'rest-client'
 >    s.add_dependency 'cul-folio-edge', '~3.1'
 #  
 #  -------------------------------------------
```

Pins my_account to previous version to avoid gemspec issue (v2.2.5).