### PR TITLE
DACCESS-371 - removes erroneous space in catalog_controller

### DIFF
--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -1155,7 +1155,7 @@ def tou
     record = eholdings_record(title_id) || []
     if record
       # recordTitle = record["data"]["attributes"]["name"]
-      record["included "].each do |package|
+      record["included"].each do |package|
         attrs = package['attributes']
         if attrs["isSelected"] == true
           packageID = attrs["packageId"]


### PR DESCRIPTION
From Christina:

I just tried to access the tou on catalog-int (https://catalog-int.library.cornell.edu/catalog/11826112) and triggered this error: https://culibrary.atlassian.net/browse/DISCOVERYACCESS-8305 which looks like it could be related, but let me know if that seems false