### PR TITLE
Fix problem with FOLIO token authentication for TOU

### DIFF
--- a/blacklight-cornell/Gemfile
+++ b/blacklight-cornell/Gemfile
@@ -125,7 +125,7 @@ gem 'blacklight_cornell_requests', git: 'https://github.com/cul-it/blacklight-co
 # gem 'blacklight_cornell_requests', :path => '/Users/matt/code/cul/d&a/blacklight-cornell-requests'
 # gem 'my_account', :path => '/Users/matt/code/cul/d&a/cul-my-account'
 gem 'cul-folio-edge', git: 'https://github.com/cul-it/cul-folio-edge', tag: 'v3.1'
-gem 'my_account', git: 'https://github.com/cul-it/cul-my-account', tag: 'v2.3.1'
+gem 'my_account', git: 'https://github.com/cul-it/cul-my-account', tag: 'v2.3.2'
 gem 'ruby-saml', '>= 1.12.1'
 gem "bento_search", "~> 2.0.0.rc1"
 gem "celluloid", "0.17.4" # Required for bento_search multisearcher

--- a/blacklight-cornell/Gemfile.lock
+++ b/blacklight-cornell/Gemfile.lock
@@ -49,10 +49,10 @@ GIT
 
 GIT
   remote: https://github.com/cul-it/cul-my-account
-  revision: 84a17456d5464515667a686cdf57265abc532f18
-  tag: v2.3.1
+  revision: 91e2c3dcf93b029ac911ef8eb87854a1eeaf826f
+  tag: v2.3.2
   specs:
-    my_account (2.3.1)
+    my_account (2.3.2)
       blacklight (>= 7.0)
       cul-folio-edge (~> 3.1)
       rails (~> 6.1)

--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -1217,8 +1217,11 @@ def tou
 
   # Return a FOLIO authentication token for API calls -- either from the session if a token
   # was prevoiusly created, or directly from FOLIO otherwise.
+  #
+  # TODO: Caching is being disabled for now, since it's causing problems with the new expiring
+  # token mechanism in FOLIO. We need to figure out how to cache the token properly. (mjc12)
   def folio_token
-    if session[:folio_token].nil?
+   #  if session[:folio_token].nil?
       url = ENV['OKAPI_URL']
       tenant = ENV['OKAPI_TENANT']
       response = CUL::FOLIO::Edge.authenticate(url, tenant, ENV['OKAPI_USER'], ENV['OKAPI_PW'])
@@ -1227,7 +1230,7 @@ def tou
       else
         session[:folio_token] = response[:token]
       end
-    end
+   #  end
     session[:folio_token]
   end
 


### PR DESCRIPTION
The new FOLIO token authentication scheme, which we started using last week, is causing unexpected problems because of the way that TOU is trying to cache the token in the Rails session. As a quick fix, this PR disables caching entirely. We'll have to figure out the right way to do it later.