### PR TITLE
DACCESS-369: remove quotes from responsibility in item record

### DIFF
--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -32,7 +32,7 @@
     <h3 class="subtitle"><%= @subtitle %></h3>
   <% end %>
   <% if responsibility.present? %>
-    <h3 class="responsibility"><%= responsibility.map(&:inspect).join('; ').gsub('\\"', '') %></h3>
+    <h3 class="responsibility"><%= responsibility.join('; ') %></h3>
   <% end %>
   </div>
   <div class="row">


### PR DESCRIPTION
Currently we are displaying quotes for title_responsibility_display on an item record ([example](https://catalog.library.cornell.edu/catalog/15633714)).

This commit (hopefully) removes those quotes without breaking anything else.