### PR TITLE
DACCESS-414 - Don't strip quotes from single-word searches in advanced edit form

### DIFF
--- a/blacklight-cornell/app/helpers/advanced_helper.rb
+++ b/blacklight-cornell/app/helpers/advanced_helper.rb
@@ -18,15 +18,8 @@ module AdvancedHelper
     end
   end
 
-  def strip_quotes(str)
-    str.sub(/\A['"]/, "").sub(/['"]\z/, "")
-  end
-
   def prep_query(raw_query)
     query = raw_query.strip
-
-    # Remove quotes if single word query
-    query = strip_quotes(query) unless query.include?(' ')
 
     # Sanitize to prevent HTML injection
     query = ActionView::Base.full_sanitizer.sanitize(query)

--- a/blacklight-cornell/spec/helpers/advanced_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/advanced_helper_spec.rb
@@ -59,12 +59,9 @@ RSpec.describe AdvancedHelper, type: :helper do
       expect(helper.prep_query("  hi \"some\" +wacky <body> text&stuff's  ")).to eq("hi \"some\" +wacky  text&amp;stuff's")
     end
 
-    it 'strips quotes if query is a single word and quoted' do
-      expect(helper.prep_query('"hello"')).to eq('hello')
-      expect(helper.prep_query("'hello'")).to eq('hello')
-    end
-
-    it 'does not strip quotes if query is multiple words and quoted' do
+    it 'does not strip quotes if query is quoted' do
+      expect(helper.prep_query('"hello"')).to eq('"hello"')
+      expect(helper.prep_query("'hello'")).to eq("'hello'")
       expect(helper.prep_query('"hello world"')).to eq('"hello world"')
       expect(helper.prep_query("'hello world'")).to eq("'hello world'")
     end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-414

Seems as though we explicitly stripped quotes for single-word searches, but this doesn't make sense to me? ~~Will check with Melissa next week to see what she thinks should happen from a UX perspective.~~ Melissa says she's not aware of any historical decisions around intentionally removing those quotes, and it does seem odd to remove them from a UX perspective.