### PR TITLE
Clean up _facets.scss

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
@@ -1,18 +1,7 @@
 .facets {
-	// background: white;
-	// ul {
-	// 	margin: 0 0 5px 10px;
-	// 	padding: 0;
-	// 	list-style: none;
-	// }
 	li {
 		font-size: .9rem;
 		padding-right: 50px;
-	}
-	p {
-		margin: 0 0 .25em;
-		border-bottom: 1px solid $light-tan;
-    	padding: 0 0 .25em 0;
 	}
 	i {
 		color: $dark-gray;
@@ -48,10 +37,11 @@
 	}
 }
 
-// OVERRIDE #FACETS - TODO: do we still need this in BL5?
-// -------------------------
-
 #facets {
+	li {
+		// Align the facet count right; needed for hieirarchical facets
+		padding-right: 0;
+	}
 	a.remove {
 		padding: 0;
 		display: inline-block;
@@ -68,9 +58,15 @@
 	span.selected {
 		color: $dark-gray;
 	}
-	h5 + div { padding-bottom: .5em; }
 }
-// TODO: ".count" may not be used in BL5
+
+// More facet link to open modal
+.more_facets {
+	margin-top: .5rem;
+	font-size: .9rem;
+}
+
+// Use monospace font for the facet count so it aligns nicely
 .facet-count {
   font-family: $monospace-font-family;
   font-size: 12px;
@@ -100,19 +96,23 @@
 	}
 }
 
+// Hierarchical call number facet
+// ------------------------------------
+
+// Indent child lists - default has no indentation
+#facets ul.facet-hierarchy ul {
+	padding-left: 1.2rem;
+	margin-bottom: .3rem;
+}
+
 // PUBLICATION YEAR
 // -----------------------
 
-.limit_content {
-	margin-right: 10px;
-	.subsection { margin-top: .5em; }
-}
 .blacklight-pub_date_facet {
 	form { margin-bottom: 1.2em; }
 	.count {
 		text-align: right;
 		float: right;
-		// color: $medium-gray;
 	}
 	.tickLabel { font-size: 0.875em; }
 	.missing,
@@ -131,13 +131,6 @@
 		}
 	}
 }
-form.range_limit {
-	input.range_begin,
-	input.range_end {
-		padding: 1px 3px;
-		width: 3em;
-	}
-}
 .navbar {
 	.blacklight-pub_date_facet {
 		.btn, .btn-group {
@@ -152,12 +145,6 @@ form.range_limit {
 	width: 89% !important;
 }
 .hover_legend { padding: 0; }
-// add a little space above the unknown value in pub year facet
-.blacklight-pub_date_facet {
-	.missing.subsection {
-		margin-top: 20px;
-	}
-}
 
 // Constraints
 // -----------------------
@@ -191,14 +178,6 @@ form.range_limit {
 	padding-bottom: .5rem;
 }
 
-// Hierarchical call number facet
-// ------------------------------------
-
-// Indent child lists - default has no indentation
-#facets ul.facet-hierarchy ul {
-	padding-left: 1.2rem;
-}
-
 // MEDIA QUERIES
 // -------------------------
 
@@ -207,10 +186,6 @@ form.range_limit {
 
 // Small devices (landscape phones, 576px and up)
 @include media-breakpoint-up(sm) {
-	.facets {
-		h5 {
-			font-size: 12px;
-		}	}
 	.facet-values {
 		.facet-label {
 			display: block;
@@ -229,11 +204,6 @@ form.range_limit {
 
 // Medium devices (tablets, 768px and up)
 @include media-breakpoint-up(md) {
-	.facets {
-		h5 {
-			font-size: 14px;
-		}
-	}
 	.facet-values {
 		.facet-label {
 			display: table-cell;

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
@@ -1,10 +1,10 @@
 .facets {
-	background: white;
-	ul {
-		margin: 0 0 5px 10px;
-		padding: 0;
-		list-style: none;
-	}
+	// background: white;
+	// ul {
+	// 	margin: 0 0 5px 10px;
+	// 	padding: 0;
+	// 	list-style: none;
+	// }
 	li {
 		font-size: .9rem;
 		padding-right: 50px;
@@ -51,20 +51,7 @@
 // OVERRIDE #FACETS - TODO: do we still need this in BL5?
 // -------------------------
 
-#sidebar {
-	padding-bottom: 0;
-}
 #facets {
-	padding-bottom: 0;
-	ul {
-		margin-left: 0;
-		padding-top: 0;
-		padding-bottom: 0;
-	}
-	li {
-		margin-right: 0;
-		padding-right: 0;
-	}
 	a.remove {
 		padding: 0;
 		display: inline-block;


### PR DESCRIPTION
- Removed/addressed TODOs
- Removed styles that were no longer needed for the hierarchical facet and range limit slider

More could probably be done. Some of these rules have been here since the start of the project and may no longer be needed. We could try to review this when we do the next major update (BL8).