### PR TITLE
DACCESS-360 - DRY up simple search param handling logic

### DIFF
--- a/blacklight-cornell/app/controllers/advanced_search_controller.rb
+++ b/blacklight-cornell/app/controllers/advanced_search_controller.rb
@@ -1,9 +1,4 @@
 class AdvancedSearchController < ApplicationController
-  # drop down problems?
-  #
-  #include Blacklight::Catalog
-  #include BlacklightCornell::CornellCatalog
-
   include LoggingHelper
 
   delegate :blacklight_config, to: :default_catalog_controller

--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -247,8 +247,8 @@ class CatalogController < ApplicationController
 
 
     config.add_facet_field 'acquired_dt_query',  label: 'Date Acquired', query: {
-      last_1_week: { label: 'Since last week', fq: "acquired_dt:[NOW-14DAY TO NOW-7DAY ]"},
-      last_1_month: { label: 'Since last month', fq: "acquired_dt:[NOW-30DAY TO NOW-7DAY ]"},
+      last_1_week: { label: 'Since last week', fq: "acquired_dt:[NOW-14DAY TO NOW-7DAY]"},
+      last_1_month: { label: 'Since last month', fq: "acquired_dt:[NOW-30DAY TO NOW-7DAY]"},
       last_1_years: { label: 'Since last year', fq: "acquired_dt:[NOW-1YEAR TO NOW-7DAY]"}
     }, if: :has_search_parameters?
 
@@ -584,138 +584,95 @@ class CatalogController < ApplicationController
     #  }
     #end
 
-    #combined author CTS field made from the multiple author browse fields
-    config.add_search_field('author_cts',:label=>'Author/Contributor') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => '$author_cts_qf',
-#         :pf => '$author_cts_pf'
-#       }
+    # Combined author CTS (Click to Search) field made from the multiple author browse fields
+    # Linked from catalog record pages
+    config.add_search_field('author_cts') do |field|
+      field.label = 'Author/Contributor'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    #combined subject CTS field made from the multiple subject browse fields
-    config.add_search_field('subject_cts',:label=>'Subject') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => '$subject_cts_qf',
-#         :pf => '$subject_cts_pf'
-#       }
+    # Combined subject CTS field made from the multiple subject browse fields
+    # Linked from catalog record pages
+    config.add_search_field('subject_cts') do |field|
+      field.label = 'Subject'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    #browse CTS fields. they do not appear in simple or advanced drop downs.
-    config.add_search_field('author_pers_browse',:label=>'Author: Personal Name') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'author_pers_browse',
-#         :pf => 'author_pers_browse'
-#       }
+    # Browse CTS fields linked to from the browse info pages
+    config.add_search_field('author_pers_browse') do |field|
+      field.label = 'Author: Personal Name'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('author_corp_browse', :label=>'Author: Corporate Name') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'author_corp_browse',
-#         :pf => 'author_corp_browse'
-#       }
+    config.add_search_field('author_corp_browse') do |field|
+      field.label = 'Author: Corporate Name'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('author_event_browse', :label=>'Author: Event') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'author_event_browse',
-#         :pf => 'author_event_browse'
-#       }
-    end
-    config.add_search_field('subject_pers_browse', :label => 'Subject: Personal Name') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'subject_pers_browse',
-#         :pf => 'subject_pers_browse'
-#       }
+    config.add_search_field('author_event_browse') do |field|
+      field.label = 'Author: Event'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('subject_corp_browse', :label => 'Subject: Corporate Name') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'subject_corp_browse',
-#         :pf => 'subject_corp_browse'
-#       }
+    config.add_search_field('subject_pers_browse') do |field|
+      field.label = 'Subject: Personal Name'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('subject_event_browse', :label => 'Subject: Event') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'subject_event_browse',
-#         :pf => 'subject_event_browse'
-#       }
+    config.add_search_field('subject_corp_browse') do |field|
+      field.label = 'Subject: Corporate Name'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('subject_topic_browse', :label => 'Subject: Topic Term') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'subject_topic_browse',
-#         :pf => 'subject_topic_browse'
-#       }
+    config.add_search_field('subject_event_browse') do |field|
+      field.label = 'Subject: Event'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('subject_era_browse', :label => 'Subject: Chronological Term') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'subject_era_browse',
-#         :pf => 'subject_era_browse'
-#       }
+    config.add_search_field('subject_topic_browse') do |field|
+      field.label = 'Subject: Topic Term'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('subject_genr_browse', :label => 'Subject: Genre/Form Term') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'subject_genr_browse',
-#         :pf => 'subject_genr_browse'
-#       }
+    config.add_search_field('subject_era_browse') do |field|
+      field.label = 'Subject: Chronological Term'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('subject_geo_browse', :label => 'Subject: Geographic Name') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
- #      field.solr_local_parameters = {
- #        :qf => 'subject_geo_browse',
- #        :pf => 'subject_geo_browse'
- #      }
+    config.add_search_field('subject_genr_browse') do |field|
+      field.label = 'Subject: Genre/Form Term'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-    config.add_search_field('subject_work_browse', :label => 'Subject: Work') do |field|
-       field.include_in_simple_select = false
-       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'subject_work_browse',
-#         :pf => 'subject_work_browse'
-#       }
+    config.add_search_field('subject_geo_browse') do |field|
+      field.label = 'Subject: Geographic Name'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
     end
 
-#    config.add_search_field('authortitle_browse', :label => 'Author (sorted by title)') do |field|
-#       field.include_in_simple_select = false
-#       field.include_in_advanced_search = false
-#       field.solr_local_parameters = {
-#         :qf => 'authortitle_browse',
-#         :pf => 'authortitle_browse'
-#       }
-#    end
+    config.add_search_field('subject_work_browse') do |field|
+      field.label = 'Subject: Work'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
+    end
 
-#    config.add_search_field('donor name') do |field|
-#       field.include_in_simple_select = false
-#       field.solr_parameters = { :qf => '$donor_t' }
-#    end
+    config.add_search_field('authortitle_browse') do |field|
+      field.label = 'Author (sorted by title)'
+      field.include_in_simple_select = false
+      field.include_in_advanced_search = false
+    end
+
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc

--- a/blacklight-cornell/app/services/blacklight/search_service.rb
+++ b/blacklight-cornell/app/services/blacklight/search_service.rb
@@ -33,7 +33,7 @@ module Blacklight
             per_page_i = @user_params[:per_page].present? ? @user_params[:per_page].to_i : 20
             last_page = search_limit/per_page_i
             @user_params[:page] = last_page
-            @search_state.params = @user_params
+            @search_state.params.merge(@user_params)
         end
 
         builder = search_builder.with(search_state)

--- a/blacklight-cornell/app/views/catalog/_search_more.html.erb
+++ b/blacklight-cornell/app/views/catalog/_search_more.html.erb
@@ -1,4 +1,4 @@
-<% unless @response.total_count < 1 && !@expanded_results.nil? %>
+<% unless @response.total_count < 1 || @expanded_results.nil? %>
     <div class="highlight-box search-more">
         <div class="heads-up">Not finding what you want?</div> 
         <p class="mb-0">

--- a/blacklight-cornell/features/catalog_search/advanced_search.feature
+++ b/blacklight-cornell/features/catalog_search/advanced_search.feature
@@ -729,7 +729,6 @@ Examples:
   | NOT | 8 | All fields | fire | complete |
 
 @DACCESS-313
-@solr_query_display
 Scenario Outline: Simple advanced search solr query matches regular search
   Given I am on the home page
     And I fill in the search box with '<search>'
@@ -738,15 +737,24 @@ Scenario Outline: Simple advanced search solr query matches regular search
     When I literally go to advanced
     And I fill in "q_row0" with '<search>'
     And I press 'advanced_search'
-    Then the solr query should be '<solr_query>'
+    Then the solr query should be '(<solr_query>)'
 
 Examples:
     | search | solr_query |
     | goblet  | ("goblet") OR phrase:"goblet" |
     | goblet of fire | ("goblet" AND "of" AND "fire") OR phrase:"goblet of fire" |
     | going fishing | ("going" AND "fishing") OR phrase:"going fishing" |
-    | "going fishing" | "\"going fishing\"" |
+    | "going fishing" | (quoted:"going fishing") |
     | fishing | ("fishing") OR phrase:"fishing" |
-    | a doll's house | ("a" AND "doll\'s" AND "house") OR phrase:"a doll\'s house" |
-    | A "fish finder" going fishing offshore | A "fish finder" going fishing offshore |
-    | | () OR phrase:"" |
+    | a doll's house | ("a" AND "doll's" AND "house") OR phrase:"a doll's house" |
+    | A "fish finder" going fishing offshore | (("A") OR phrase:"A") AND (quoted:"fish finder") AND (("going" AND "fishing" AND "offshore") OR phrase:"going fishing offshore") |
+
+Scenario: Empty searches produce empty solr queries in advanced and simple search
+  Given I am on the home page
+    And I fill in the search box with ''
+    And I press 'search'
+    Then the solr query should be ''
+    When I literally go to advanced
+    And I fill in "q_row0" with ''
+    And I press 'advanced_search'
+    Then the solr query should be ''

--- a/blacklight-cornell/features/catalog_search/results_list.feature
+++ b/blacklight-cornell/features/catalog_search/results_list.feature
@@ -379,3 +379,10 @@ Feature: Results list
     Then I should get results
     And I should see the label 'Birds I have kept in years gone by'
     And I should see a facets sidebar
+
+  @javascript
+  Scenario: I can't see more than 20,000 search results
+    Given I am on the home page
+    And I press 'search'
+    And I navigate to a page that exceeds search results
+    Then I should see the text 'Search limit exceeded. To view additional results, modify your search using the available filters.'

--- a/blacklight-cornell/features/step_definitions/advanced_search_steps.rb
+++ b/blacklight-cornell/features/step_definitions/advanced_search_steps.rb
@@ -32,7 +32,7 @@ When("I view the {string} version of the search results") do |format|
   visit new_url
 end
 
-Then("the solr query should be {string}") do |string|
+Then /^the solr query should be '(.*?)'$/ do |string|
   sq = page.find("dl#solr-query-display > dd").text
   expect(sq).to eq(string)
 end

--- a/blacklight-cornell/features/step_definitions/results_list_steps.rb
+++ b/blacklight-cornell/features/step_definitions/results_list_steps.rb
@@ -105,3 +105,13 @@ Then("all ids are unique") do
     end
   end
 end
+
+Then('I navigate to a page that exceeds search results') do
+  RSpec::Mocks.with_temporary_scope do
+    Rails.configuration.stub(:search_limit).and_return(50)
+
+    within 'ul.pagination' do
+      click_link '5'
+    end
+  end
+end

--- a/blacklight-cornell/jenkins-opts.sh
+++ b/blacklight-cornell/jenkins-opts.sh
@@ -12,7 +12,6 @@ OPT5="-t ~@boundwith  -p jenkins_lax --format junit --out results/ "
 OPT3="-t ~@boundwith  -p jenkins_lax "
 OPT2="-t ~@search_availability_title_mission_etrangeres_missing "
 OPT4=" -t ~@saml_off "
-OPT6="-t ~@solr_query_display"
 
 # OPT1="--tags 'not @oclc_request'"
 # OPT2="--tags 'not @search_with_view_all_webs_match_box_with_percent'"
@@ -30,8 +29,8 @@ echo "Arguments:"
 echo $ARGS
 
 if [ $# -eq 0 ]; then
-    COVERAGE=on bundle exec cucumber $ARGS $OPT1 $OPT2 $OPT3 $OPT4 $OPT5 $OPT6
+    COVERAGE=on bundle exec cucumber $ARGS $OPT1 $OPT2 $OPT3 $OPT4 $OPT5
 else
-    COVERAGE=on bundle exec cucumber $ARGS $OPT1 $OPT2 $OPT3 $OPT4 $OPT5 $OPT6 "$1"
+    COVERAGE=on bundle exec cucumber $ARGS $OPT1 $OPT2 $OPT3 $OPT4 $OPT5 "$1"
 fi
 

--- a/blacklight-cornell/lib/blacklight_cornell/cornell_catalog.rb
+++ b/blacklight-cornell/lib/blacklight_cornell/cornell_catalog.rb
@@ -115,6 +115,8 @@ module BlacklightCornell::CornellCatalog extend Blacklight::Catalog
       params[:qdisplay] = ''
     end
     search_session[:per_page] = params[:per_page]
+
+    # TODO: Review all this code. Why is this here and not in SearchBuilder?
     temp_search_field = ''
     journal_titleHold = ''
     if (!params[:range].nil?)

--- a/blacklight-cornell/lib/blacklight_cornell/cornell_catalog.rb
+++ b/blacklight-cornell/lib/blacklight_cornell/cornell_catalog.rb
@@ -139,25 +139,13 @@ module BlacklightCornell::CornellCatalog extend Blacklight::Catalog
       @filters = params[:f] || []
     end
 
-    @expanded_results = {}
-    ['worldcat'].each do |key|
-      @expanded_results [key] =  { :count => 0 , :url => '' }
-    end
-
     # Expand search only under certain conditions
-    tmp = BentoSearch::Results.new
-    if !(params[:search_field] == 'lc_callnum')
-      if expandable_search?
-        # DISCOVERYACCESS-6734 - skip entire worldcat search that was intended to provide a count for worldcat results
-        query = ( params[:qdisplay]?params[:qdisplay] : params[:q]).gsub(/&/, '%26')
-        key = :worldcat
-        source_results = {
-          :count => 1,
-          :url => BentoSearch.get_engine(key).configuration.link + query,
-        }
-        @expanded_results = {}
-        @expanded_results[key.to_s] = source_results
-      end
+    if expandable_search?
+      query = params[:q].gsub(/&/, '%26')
+      source_results = { :url => BentoSearch.get_engine(:worldcat).configuration.link + query }
+      @expanded_results = { 'worldcat' => source_results }
+    else
+      @expanded_results = { 'worldcat' => { :url => ENV['WORLDCAT_URL'] } }
     end
 
     @controller = self

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
         STORAGE_URL = "http://digcoll.internal.library.cornell.edu:8080/fcrepo/rest"
         COLLECTIONS = "development"
         CATALOG = "http://da-prod-solr.library.cornell.edu/solr/blacklight"
+        DISPLAY_SOLR_QUERY = 1
         }
     stages {
         stage('Set up and run bundler') {

--- a/jenkins/cucumber-features.sh
+++ b/jenkins/cucumber-features.sh
@@ -12,14 +12,13 @@ OPT1="-t ~@oclc_request  -t ~@search_with_view_all_webs_match_box_with_percent "
 OPT3="-t ~@boundwith  -p jenkins_lax --format junit --out results/ "
 OPT2="-t ~@search_availability_title_mission_etrangeres_missing "
 OPT4=" -t ~@saml_off "
-OPT5="-t ~@solr_query_display "
 export COVERAGE=on
 export RAILS_ENV=test
 if [ -z ${CUCUMBER_FEATURE_TESTS+x} ]
     then
         echo "Running all feature tests."
-        bundle exec cucumber $OPT1 $OPT2 $OPT3 $OPT4 $OPT5
+        bundle exec cucumber $OPT1 $OPT2 $OPT3 $OPT4
     else
         echo "Running feature: ${CUCUMBER_FEATURE_TESTS}"
-        bundle exec cucumber $OPT1 $OPT2 $OPT3 $OPT4 $OPT5 "${CUCUMBER_FEATURE_TESTS}"
+        bundle exec cucumber $OPT1 $OPT2 $OPT3 $OPT4 "${CUCUMBER_FEATURE_TESTS}"
 fi


### PR DESCRIPTION
Summary: Reuses search param handling logic in SearchBuilder from advanced search for simple search, cleans up unused search param handling logic from CornellCatalog#index, fixes a couple adjacent bugs. More details:

In simple search:
- Uses boolean operators (`AND`, `OR`) instead of prefix operator (`-`)
- Wraps query strings in quotation marks
- Consistent handling of special characters across both simple and advanced search (replaces `“` with `"`, removes `()[]`, escapes `: + -`)
- Fixes edge case bug where simple searches that started with a parentheses and contains a quotation mark searches the author solr field, e.g. https://catalog-int.library.cornell.edu/catalog?q=%28%22Uprooted%22%29&search_field=title
- Fixes bug where author-title "Total Works" search links displays "All Fields" as its search field constraint, instead of "Author (sorted by title)", e.g. https://catalog-int.library.cornell.edu/?q=%22Beethoven,%20Kaspar%20Karl%20van,%201774-1815.%20|%20Minuets,%20orchestra%22&search_field=authortitle_browse
- Fixes [DACCESS-471](https://culibrary.atlassian.net/browse/DACCESS-471), where user receives 500 when exceeding search limits
- Fixes [DACCESS-474](https://culibrary.atlassian.net/browse/DACCESS-474), where links to worldcat sometimes go nowhere

~~TODO:~~
- ~~Maybe consider moving code out of SearchBuilder into separate QueryBuilder object?~~ Will wait until removing prefix operators from bento search, since then it'll be more necessary to have reusable logic outside SearchBuilder.

[DACCESS-471]: https://culibrary.atlassian.net/browse/DACCESS-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-474]: https://culibrary.atlassian.net/browse/DACCESS-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ