### PR TITLE
DACCESS-363: fix empty <h2> heading on New TOU view

### DIFF
--- a/blacklight-cornell/app/views/catalog/new_tou.html.erb
+++ b/blacklight-cornell/app/views/catalog/new_tou.html.erb
@@ -18,7 +18,7 @@
         Back to Item
       <% end %>
     </div>
-    <h2>
+    <h2>Terms of Use</h2>
   </div>
 </div>
 <div class="resources">


### PR DESCRIPTION
Currently we have an accessibility error due to an empty `h2` on the Terms of Use page that is generated from the availability box. For example:
https://catalog.library.cornell.edu/catalog/new_tou/1350008/15085364

I added "Terms of Use" to this heading, which should clear the error and hopefully give a bit more context to the content.