### PR TITLE
Prevent patrons from exceeding the char limit 

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/aeon/_aeon_custom.scss
+++ b/blacklight-cornell/app/assets/stylesheets/aeon/_aeon_custom.scss
@@ -206,7 +206,15 @@ input[type="button"]#clear {
 .fa-warning:before {
   content: "\f071";
 }
-
+.fa-charmax-alert {
+    color: red;
+}
+.charmax-alert {
+    color: red;
+}
+.fa-charmax-alert:before {
+    content: "\f06a";
+}
 .info-wrapper
 {
     padding-left: 10px;

--- a/blacklight-cornell/app/views/aeon/_aeon_scan_body.html.erb
+++ b/blacklight-cornell/app/views/aeon/_aeon_scan_body.html.erb
@@ -48,8 +48,19 @@
 </div>
 <div class="form-group">
         <label for="SpecialRequest">Please enter any deadlines, special requests or questions for library staff.</label>
-        <textarea class="form-control col-md-6" id="SpecialRequest" name="SpecialRequest" rows="3"></textarea>
+        <textarea class="form-control col-md-6" id="SpecialRequest" name="SpecialRequest" rows="3" maxlength="250" oninput="checkLength()" aria-describedby="charWarning"></textarea>
+        <div id="charWarning" style="color: red; display: none;" role="alert" aria-live="assertive">You have reached the 250 character limit.</div>
 </div>
+<script>
+        // when character max limit is reached, show (and announce to screen readers) a warning message 
+        function checkLength() {
+                if (document.getElementById('SpecialRequest').value.length >= 250) {
+                        document.getElementById('charWarning').style.display = 'block';
+                } else {
+                        document.getElementById('charWarning').style.display = 'none';
+                }
+        }
+</script>
 <div class="form-group">
         <label for="Notes">Add any notes about this item or request that may be helpful for your own personal reference later.</label>
         <textarea class="form-control col-md-6" id="Notes" name="Notes" rows="3"></textarea>

--- a/blacklight-cornell/app/views/aeon/_aeon_scan_body.html.erb
+++ b/blacklight-cornell/app/views/aeon/_aeon_scan_body.html.erb
@@ -49,7 +49,9 @@
 <div class="form-group">
         <label for="SpecialRequest">Please enter any deadlines, special requests or questions for library staff.</label>
         <textarea class="form-control col-md-6" id="SpecialRequest" name="SpecialRequest" rows="3" maxlength="250" oninput="checkLength()" aria-describedby="charWarning"></textarea>
-        <div id="charWarning" style="color: red; display: none;" role="alert" aria-live="assertive">You have reached the 250 character limit.</div>
+        <div id="charWarning" class="charmax-alert" style="display: none;" role="alert" aria-live="assertive">
+                <i class="fa fa-charmax-alert"></i> You have reached the 250 character limit.
+        </div>
 </div>
 <script>
         // when character max limit is reached, show (and announce to screen readers) a warning message 


### PR DESCRIPTION
Prevent patrons from exceeding the char limit in the special requests in field, and show a warning message
- this was causing issues when the limit was exceeded and the routing rules did not get enforced
- this is screen reader friendly
<img width="597" alt="image" src="https://github.com/user-attachments/assets/dfd9d236-3941-46a1-adf3-30cefb3f51dc" />
