### PR TITLE
DACCESS-411 - Add sort by date acquired option

### DIFF
--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -685,7 +685,7 @@ class CatalogController < ApplicationController
     config.add_sort_field 'title_sort asc, pub_date_sort desc', :label => 'title A-Z', :browse_default => true
     config.add_sort_field 'title_sort desc, pub_date_sort desc', :label => 'title Z-A'
     config.add_sort_field 'callnum_sort asc, pub_date_sort desc', :label => 'call number', :callnum_default => true
-    #config.add_sort_field 'acquired_dt desc, title_sort asc', :label => 'date acquired'
+    config.add_sort_field 'acquired_dt desc, title_sort asc', :label => 'date acquired'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/blacklight-cornell/spec/helpers/advanced_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/advanced_helper_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe AdvancedHelper, type: :helper do
         ['author Z-A', 'author_sort desc, title_sort asc'],
         ['title A-Z', 'title_sort asc, pub_date_sort desc'],
         ['title Z-A', 'title_sort desc, pub_date_sort desc'],
-        ['call number', 'callnum_sort asc, pub_date_sort desc']
+        ['call number', 'callnum_sort asc, pub_date_sort desc'],
+        ['date acquired', 'acquired_dt desc, title_sort asc']
       ])
     end
   end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-411

Adds a "date acquired" sort to simple and advanced search which sorts items by acquired_dt desc (newest -> oldest), then title A-Z.

Items with null acquired_dt appear at end of search results list.