### PR TITLE
DACCESS-487: add click event for Articles & Full Text, update event f…

### DIFF
--- a/blacklight-cornell/app/views/single_search/_pane_results.html.erb
+++ b/blacklight-cornell/app/views/single_search/_pane_results.html.erb
@@ -16,16 +16,16 @@
     <%= bento_search result  %>
     <div class="view-all">
       <% if key == "libguides" %>
-        <%= link_to 'View All Research Guides', 'http://guides.library.cornell.edu/libguides/home', :class => "btn btn-outline-secondary btn-sm", :id => "link_top_libguides" %>
+        <%= link_to 'View All Research Guides', 'http://guides.library.cornell.edu/libguides/home', :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', 'LibGuides'])", :id => "link_top_libguides" %>
       <% elsif key == "ebsco_eds" %>
-        <%= link_to link_url, :class => "btn btn-outline-secondary btn-sm" do %>
+        <%= link_to link_url, :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', 'Articles & Full Text'])" do %>
           View
           <%= number_with_delimiter(result.total_items) %>
           <%= BentoSearch.get_engine(key).configuration.title %>
           <i class="fa fa-angle-double-right"></i>
         <% end %>
       <% else %>
-      <%= link_to link_url, :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', '#{BentoSearch.get_engine(key).configuration.blacklight_format}'])", :id => "link_top_" + downcast(key) do %>
+      <%= link_to link_url, :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', '#{BentoSearch.get_engine(key).configuration.title}'])", :id => "link_top_" + downcast(key) do %>
         View
         <!-- = '(r%2.3f)' % (@scores[key].nil? ? 0 : @scores[key])
         -->

--- a/blacklight-cornell/app/views/single_search/_pane_results.html.erb
+++ b/blacklight-cornell/app/views/single_search/_pane_results.html.erb
@@ -25,7 +25,7 @@
           <i class="fa fa-angle-double-right"></i>
         <% end %>
       <% else %>
-      <%= link_to link_url, :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', '#{BentoSearch.get_engine(key).configuration.title}'])", :id => "link_top_" + downcast(key) do %>
+      <%= link_to link_url, class: "btn btn-outline-secondary btn-sm", onclick: "javascript:_paq.push(['trackEvent', 'allResultsLink', '#{BentoSearch.get_engine(key).configuration.blacklight_format || BentoSearch.get_engine(key).configuration.title}'])", id: "link_top_" + downcast(key) do %>
         View
         <!-- = '(r%2.3f)' % (@scores[key].nil? ? 0 : @scores[key])
         -->


### PR DESCRIPTION
…or other formats

Currently in the bento we have a Matomo events on some of the "View all" buttons for each bento box — except we are missing one for Articles & Full Text (EDS). This event tracks the number of clicks on each button so we can get a sense of their usage. I also added an event for LibGuides.

In the process I noticed that Digital Collections and Repositories also didn't have click tracking. Instead of using `blacklight_format`, I changed it to `title` since Digital Collections and Repositories don't have a blacklight format.

One consequence is that the click label in Matomo for the formats is slightly different with this change -- instead of "Book", the label is now "Books." That kind of throws off the data, but I think we can live with this change. Unless there's a better way to do it.