### PR TITLE
DACCESS-472 - broken bookmarks item details page

### DIFF
--- a/blacklight-cornell/app/helpers/display_helper.rb
+++ b/blacklight-cornell/app/helpers/display_helper.rb
@@ -906,13 +906,17 @@ end
   end
 
   # Overrides original method from blacklight_helper_behavior.rb
+  # Creates a link to the show page for an item
+  # @param doc [SolrDocument] the document
+  # @param field_or_opts [Hash, String] either a string to render as the link text or options
+  # @param opts [Hash] the options to create the link with
   def link_to_document(doc, field_or_opts = nil, opts={:label=>nil, :counter => nil, :results_view => true})
-    # opts[:label] ||= blacklight_config.index.show_link.to_sym unless blacklight_config.index.show_link == nil
-    # label = _cornell_render_document_index_label doc, opts
-    if ['bookmarks', 'book_bags'].include? params[:controller] 
-      label = field_or_opts
-      docID = doc.id
+    label = field_or_opts
+    docID = doc.id
+    if ['book_bags'].include? params[:controller] 
       link_to label, '/' + params[:controller] + '/' + docID
+    elsif ['bookmarks'].include? params[:controller]
+      link_to label, '/catalog/' + docID
     else
       # link_to label, doc, { :'data-counter' => opts[:counter] }.merge(opts.reject { |k,v| [:label, :counter, :results_view].include? k  })
       super

--- a/blacklight-cornell/app/helpers/display_helper.rb
+++ b/blacklight-cornell/app/helpers/display_helper.rb
@@ -906,17 +906,13 @@ end
   end
 
   # Overrides original method from blacklight_helper_behavior.rb
-  # Creates a link to the show page for an item
-  # @param doc [SolrDocument] the document
-  # @param field_or_opts [Hash, String] either a string to render as the link text or options
-  # @param opts [Hash] the options to create the link with
   def link_to_document(doc, field_or_opts = nil, opts={:label=>nil, :counter => nil, :results_view => true})
-    label = field_or_opts
-    docID = doc.id
-    if ['book_bags'].include? params[:controller] 
+    # opts[:label] ||= blacklight_config.index.show_link.to_sym unless blacklight_config.index.show_link == nil
+    # label = _cornell_render_document_index_label doc, opts
+    if ['bookmarks', 'book_bags'].include? params[:controller] 
+      label = field_or_opts
+      docID = doc.id
       link_to label, '/' + params[:controller] + '/' + docID
-    elsif ['bookmarks'].include? params[:controller]
-      link_to label, '/catalog/' + docID
     else
       # link_to label, doc, { :'data-counter' => opts[:counter] }.merge(opts.reject { |k,v| [:label, :counter, :results_view].include? k  })
       super

--- a/blacklight-cornell/config/routes.rb
+++ b/blacklight-cornell/config/routes.rb
@@ -42,7 +42,6 @@ BlacklightCornell::Application.routes.draw do
 
   resources :bookmarks do
     concerns :exportable
-    concerns :searchable
 
     collection do
       delete "clear"

--- a/blacklight-cornell/features/catalog_search/bookmarks.feature
+++ b/blacklight-cornell/features/catalog_search/bookmarks.feature
@@ -104,3 +104,19 @@ Feature: Bookmarks for anonymous users
         Then I should see the CUWebLogin page
         Then I clear login required
 
+    @bookmarks_view_item_details
+    Scenario: I should be able to view the item details page for a selected item
+        Given I am on the home page
+        When I fill in the search box with 'Encyclopedia of pain'
+        And I press 'search'
+        Then I should get results
+        Then I select the first 1 catalog results
+        And I sleep 3 seconds
+        When I view my selected items
+        Then I should be on 'the bookmarks page'
+        And there should be 1 items selected
+        Then I click on link "Encyclopedia of pain"
+        Then I should see "Encyclopedia of pain"
+        Then I click on link "Back to selected items"
+        Then I should be on 'the bookmarks page'
+        And there should be 1 items selected


### PR DESCRIPTION
I did not use the super for bookmarks because that includes the data-context-href attribute to the link and it doesn't make sense to track for bookmarks
- I would like to test on integration first before merging to dev if this code change looks ok to you both