### PR TITLE
DACCESS-489: fix click events on non-catalog links in bento

### DIFF
--- a/blacklight-cornell/app/views/bento_search/_item_title.html.erb
+++ b/blacklight-cornell/app/views/bento_search/_item_title.html.erb
@@ -25,10 +25,9 @@
       <% end %>
     <% end %>
     <% if item.format.is_a?(Array) %>
-    <%= link_to_unless(item.link.blank?, item.complete_title, item.link,{:onclick => "javascript:_paq.push(['trackEvent', 'BentoBox', '#{item.format[0].to_s + " item"}'])"}) %>
+    <%= link_to_unless(item.link.blank?, item.complete_title, item.link,{:onclick => "javascript:_paq.push(['trackEvent', 'BentoBox', '#{item.format[0].to_s} result'])"}) %>
     <% else %>
-    <%= link_to_unless(item.link.blank?, item.complete_title, item.link,{:onclick => "javascript:_paq.push(['trackEvent', 'BentoBox', '#{item.engine_id + " item"}'])"}) %>
-
+    <%= link_to_unless(item.link.blank?, item.complete_title, item.link,{:onclick => "javascript:_paq.push(['trackEvent', 'BentoBox', '#{item.engine_id} result'])"}) %>
     <% end %>
 
     <% if item.display_language.present? %>

--- a/blacklight-cornell/app/views/bento_search/_item_title.html.erb
+++ b/blacklight-cornell/app/views/bento_search/_item_title.html.erb
@@ -25,9 +25,9 @@
       <% end %>
     <% end %>
     <% if item.format.is_a?(Array) %>
-    <%= link_to_unless(item.link.blank?, item.complete_title, item.link,{:onclick => "javascript:_paq.push(['trackEvent', '#{item.format[0].to_s}', 'BentoBox'])"}) %>
+    <%= link_to_unless(item.link.blank?, item.complete_title, item.link,{:onclick => "javascript:_paq.push(['trackEvent', 'BentoBox', '#{item.format[0].to_s + " item"}'])"}) %>
     <% else %>
-    <%= link_to_unless(item.link.blank?, item.complete_title, item.link,{:onclick => "javascript:_paq.push(['trackEvent', '#{item.format}', 'BentoBox'])"}) %>
+    <%= link_to_unless(item.link.blank?, item.complete_title, item.link,{:onclick => "javascript:_paq.push(['trackEvent', 'BentoBox', '#{item.engine_id + " item"}'])"}) %>
 
     <% end %>
 


### PR DESCRIPTION
It looks like we have Matomo click events on result links in the bento box, but they are empty for Articles & Full Text, Digital Collections, Repositories, and Research Guides. This PR:

- uses the bento engine ID for the matomo label for these links
- switches the order of Matomo labels so that BentoBox is the category under which the format or engine ID are displayed on webstats.library.cornell.edu