### PR TITLE
Update My Account and Edge library

### DIFF
--- a/blacklight-cornell/Gemfile
+++ b/blacklight-cornell/Gemfile
@@ -122,8 +122,8 @@ gem "font-awesome-rails"
 gem "blacklight_cornell_requests", git: "https://github.com/cul-it/blacklight-cornell-requests", tag: "v5.2"
 # gem 'blacklight_cornell_requests', :path => '/Users/matt/code/cul/d&a/blacklight-cornell-requests'
 # gem 'my_account', :path => '/Users/matt/code/cul/d&a/cul-my-account'
-gem "cul-folio-edge", git: "https://github.com/cul-it/cul-folio-edge", tag: "v3.1"
-gem "my_account", git: "https://github.com/cul-it/cul-my-account", tag: "v2.3.3"
+gem "cul-folio-edge", git: "https://github.com/cul-it/cul-folio-edge", tag: "v3.2"
+gem "my_account", git: "https://github.com/cul-it/cul-my-account", tag: "v2.3.4"
 gem "ruby-saml", ">= 1.12.1"
 gem "bento_search", "~> 2.0.0.rc1"
 gem "celluloid", "0.17.4" # Required for bento_search multisearcher

--- a/blacklight-cornell/Gemfile.lock
+++ b/blacklight-cornell/Gemfile.lock
@@ -40,20 +40,20 @@ GIT
 
 GIT
   remote: https://github.com/cul-it/cul-folio-edge
-  revision: c34dab4611ce57dfca2308344e03a72dbc92ff44
-  tag: v3.1
+  revision: bfdc3a28749ce826caf7dd1c415dd044a72a8b4f
+  tag: v3.2
   specs:
-    cul-folio-edge (3.1)
+    cul-folio-edge (3.2)
       rest-client
 
 GIT
   remote: https://github.com/cul-it/cul-my-account
-  revision: c03cd679cb1d730e1f1da24705854941c7e566ad
-  tag: v2.3.3
+  revision: 81a6040fff2fe0e2e534cd32deb68a7fa0e926be
+  tag: v2.3.4
   specs:
-    my_account (2.3.3)
+    my_account (2.3.4)
       blacklight (>= 7.0)
-      cul-folio-edge (~> 3.1)
+      cul-folio-edge (~> 3.2)
       rails (~> 6.1)
       rest-client
       xml-simple


### PR DESCRIPTION
This updates the Gemfile and Gemfile.lock with new versions of the My Account engine and cul-folio-edge libraries:

[My Account v2.3.4](https://github.com/cul-it/cul-my-account/releases/tag/v2.3.4)
[cul-folio-edge v3.2](https://github.com/cul-it/cul-folio-edge/releases/tag/v3.2)

**Note that these changes also require two new keys for the .env file**:
`MY_ACCOUNT_ILLIAD_API_URL`
`MY_ACCOUNT_ILLIAD_API_KEY`