### PR TITLE
DACCESS-499 - Set solr f even when facet is not defined

### DIFF
--- a/blacklight-cornell/features/catalog_search/facets.feature
+++ b/blacklight-cornell/features/catalog_search/facets.feature
@@ -130,3 +130,7 @@ Feature: Facets
 		| lc_callnum_facet | Call Number | x |
 		| collection | Collection | x |
 		# wip | acquired_dt_query | Date Acquired | yes |
+
+Scenario: Filtering searches by facets that are not available in the public ui
+	When I literally go to ?f[availability_facet][]=Checked%20out
+	Then I should get 10 results

--- a/blacklight-cornell/spec/models/search_builder_spec.rb
+++ b/blacklight-cornell/spec/models/search_builder_spec.rb
@@ -2188,4 +2188,42 @@ RSpec.describe SearchBuilder, type: :model do
       end
     end
   end
+
+  describe '#set_fq' do
+    before do
+      allow(search_builder).to receive(:blacklight_params) { blacklight_params }
+    end
+
+    context 'empty q and search_field' do
+      let(:blacklight_params) { {
+        f: {
+          'author_facet' => ['Bayerische Staatsbibliothek'],
+          'subject_topic_lc_facet' => ['Block-books, Tibetan']
+        }
+      } }
+
+      it 'populates solr fq' do
+        solr_params = { fq: ['{!term f=author_facet}Bayerische Staatsbibliothek'] }
+        search_builder.set_fq(solr_params)
+        expect(solr_params[:fq]).to eq(['{!term f=author_facet}Bayerische Staatsbibliothek',
+                                        '{!term f=subject_topic_lc_facet}Block-books, Tibetan'])
+      end
+    end
+
+    context 'existing q and search_field' do
+      let(:blacklight_params) { {
+        f: {
+          'subject_topic_lc_facet' => ['Block-books, Tibetan']
+        },
+        q: 'tibetan',
+        search_field: 'all_fields'
+      } }
+
+      it 'populates solr fq' do
+        solr_params = {}
+        search_builder.set_fq(solr_params)
+        expect(solr_params[:fq]).to eq(['{!term f=subject_topic_lc_facet}Block-books, Tibetan'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-499

Deployed to catalog-int. Examples:

- https://catalog-int.library.cornell.edu/?f%5bsubject_sub_lc_facet%5d%5b%5d=Blacks - 0 results, but confirmed that this matched solr.
- https://catalog-int.library.cornell.edu/?f%5bsubject_topic_lc_facet%5d%5b%5d=Block-books,%20Tibetan
- https://catalog-int.library.cornell.edu/?f[subject_topic_lc_facet][]=Bamboo%20carving%20%3E%20(China)

Hoping to do a prod deploy tomorrow morning.