### PR TITLE
fix - newline characters not accepted in Aeon

### DIFF
--- a/blacklight-cornell/app/assets/javascripts/aeon/request.js
+++ b/blacklight-cornell/app/assets/javascripts/aeon/request.js
@@ -66,6 +66,9 @@ function doSubmit(_) {
     return false;
   }
 
+  // Replace newline characters - not accepted in Aeon and break routing
+  $('#SpecialRequest').val($('#SpecialRequest').val().replace(/\r?\n|\r/g, ' --- '));
+
   if(numSelected == "1") { 
     // for a single item request, hidden input field names can NOT have that ID appended
     $('.ItemNo').each((_, element) => buildRequestForItem(_, element, false));


### PR DESCRIPTION
For photoduplication requests, the special requests field can not accept new line characters. The citation and my notes fields work fine with new line characters. This might be because of restrictions for the special requests set in Aeon.  