### PR TITLE
Aeon bug fixes

### DIFF
--- a/blacklight-cornell/app/assets/javascripts/aeon/request.js
+++ b/blacklight-cornell/app/assets/javascripts/aeon/request.js
@@ -66,6 +66,9 @@ function doSubmit(_) {
     return false;
   }
 
+  // Replace newline characters - not accepted in Aeon and break routing
+  $('#SpecialRequest').val($('#SpecialRequest').val().replace(/\r?\n|\r/g, ' --- '));
+
   if(numSelected == "1") { 
     // for a single item request, hidden input field names can NOT have that ID appended
     $('.ItemNo').each((_, element) => buildRequestForItem(_, element, false));

--- a/blacklight-cornell/app/assets/javascripts/aeon/request.js
+++ b/blacklight-cornell/app/assets/javascripts/aeon/request.js
@@ -42,7 +42,8 @@ function buildRequestForItem(_, element, multipleFlag) {
       { name: `CallNumber`, value: callnumber },
       { name: `ItemInfo1`, value: chron },
       { name: `ItemNumber`, value: barcode },
-      { name: `ItemIssue`, value: copy }
+      { name: `ItemIssue`, value: copy },
+      { name: `Site`, value: (cslocation + ' ' + location).toLowerCase().includes('rmc') ? 'RMC' : 'KHEEL' },
     ];
     $("#RequestForm").append(`<input type="hidden" class="dynamic-input" name="Request" value="${req}">`);
     const ext = multipleFlag ? `_${req}` : '';

--- a/blacklight-cornell/app/views/aeon/reading_room_request.html.erb
+++ b/blacklight-cornell/app/views/aeon/reading_room_request.html.erb
@@ -64,18 +64,8 @@
 			
 				<% @form_source = @form_source.include?("aeon") ? "aeon" : @form_source.include?("nonshib") ? "nonshib" : @form_source %>
 			
-				<% rmc_site = true %>
-				<% holdings.each do |_, holding| %>
-					<% location = holding['location'] %>
-					<% if location && (location['code'].downcase.include?('kheel') || location['name'].downcase.include?('kheel')) %>
-						<% rmc_site = false %>
-						<% break %>
-					<% end %>
-				<% end %>
-
 				<form id="RequestForm" method="POST" action="https://rmc-aeon.library.cornell.edu/<%= @form_source %>/aeon.dll">	
 					<%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
-					<input type="hidden" name="Site" value="<%= rmc_site ? 'RMC' : 'KHEEL' %>"/>
 					<input type="hidden" id="ReferenceNumber" name="ReferenceNumber" value="<%= @bibid %>"/>
 					<input type="hidden" name="WebRequestForm" value="GenericRequestManuscript"/>
 					<input type="hidden" id="AeonForm" name="AeonForm" value="EADRequest"/>

--- a/blacklight-cornell/app/views/aeon/scan_aeon.html.erb
+++ b/blacklight-cornell/app/views/aeon/scan_aeon.html.erb
@@ -86,14 +86,13 @@
 					<input type="hidden" name="SkipOrderEstimate" value="Yes">
 					<input type="hidden" id="ReferenceNumber" name="ReferenceNumber" value="<%= @bibid %>"/>
 					<input type="hidden" name="AeonForm" value="ExternalRequest">
-					<input type="hidden" name="Site" value="<%= rmc_site ? 'RMC' : 'KHEEL' %>"/>
 					<input type="hidden" name="SystemID" value="Aeon Copy">
 					<input type="hidden" name="WebRequestForm" value="PhotoduplicationRequest">
 					<input type="hidden" id="SubmitButton" name="SubmitButton" value="Submit Request"/>
 					<input type="hidden" name="RequestType" value="Copy">
 					<input type="hidden" id="DocumentType" name="DocumentType" value="Photoduplication"/>	
 					<input type="hidden" name="FormValidationOverride" value="AllRequests">
-					<input type="hidden" name="SkipFieldLengthValidation" value="yes">
+					<input type="hidden" name="SkipFieldLengthValidation" value="no">
 					<input type="hidden" id="Restrictions" name="Restrictions" value="<%= @re506 %>">
 					<input type="hidden" id="ItemInfo3" name="ItemInfo3" value="<%= @re506 %>">
 					<input type="hidden" id="ItemInfo5" name="ItemInfo5" value="">

--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -224,8 +224,7 @@
        			<% if holdings[k]["active"].nil? or holdings[k]["active"] == true %>
 
 	             		<% if holding["location"].present? %>
-	                		<% if holding["location"]["name"].include?('Rare') %>
-								<%# || holding["location"]["name"].include?('Kheel') %>
+	                		<% if holding["location"]["name"].include?('Rare') || holding["location"]["name"].include?('Kheel') %>
 	                   			<% rare_items << holding %>
 	                		<% else %>
 	                		   <% circulating_items << holding %>


### PR DESCRIPTION
DACCESS-462 - enforce field limit. Tuns out this field is important when you clone a request in the Aeon web client pages, it will use this value and the validating for the form on the Aeon web client doesn't work if this is not set properly

DACCESS-507 - Create the Site form field dynamically on a form submit in the js function buildRequestForItem - because it is now item specific. This edge case was found on catalog/7673328 where you could possible request both a KHEEL item and a RMC item