### PR TITLE
Eliminate redundant API key

### DIFF
--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -948,7 +948,7 @@ def tou
     token = folio_token
     if url && token
       headers = {
-        'X-Okapi-Tenant' => ENV['TENANT_ID'],
+        'X-Okapi-Tenant' => ENV['OKAPI_TENANT'],
         'x-okapi-token' => token,
         :accept => 'application/json, application/vnd.api+json'
       }


### PR DESCRIPTION
We have two env keys with the same value. This is the one place where the one key is used, so changing this line will allow us to eliminate the redundant key.