### PR TITLE
Update Hours link path

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
@@ -1,7 +1,6 @@
 .facets {
 	background: white;
 	ul {
-		margin: 0 0 5px 10px;
 		padding: 0;
 		list-style: none;
 	}
@@ -111,9 +110,18 @@
 // ------------------------------------
 
 // Indent child lists - default has no indentation
-#facets ul.facet-hierarchy ul {
-	padding-left: 1.2rem;
-	margin-bottom: .3rem;
+#facets ul.facet-hierarchy  {
+	ul {
+		padding-left: 1.2rem;
+		margin-bottom: .3rem;
+	}
+	.h-leaf {
+		padding-left: 1.4rem;
+	}
+}
+
+.facet-hierarchy .twiddle > .toggle-handle .toggle-icon {
+	margin-top: 0;
 }
 
 // PUBLICATION YEAR

--- a/blacklight-cornell/app/views/catalog/_holdings_group.html.erb
+++ b/blacklight-cornell/app/views/catalog/_holdings_group.html.erb
@@ -61,10 +61,10 @@
             <% if i["location"]["hoursCode"] == "spif" %>
               <%= link_to "Hours", "https://cornellspif.com/contact-spif/", "aria-label" => i["location"]["name"] + " Hours" %>
             <% else %>
-              <% if i["location"]["hoursCode"] == "ciser" %>
-                <%= link_to "Hours", "https://ciser.cornell.edu/", "aria-label" => i["location"]["name"] + " Hours" %>
+              <% if i["location"]["hoursCode"] == "ornithology" %>
+                <%= link_to "Hours", "https://www.birds.cornell.edu/home/visit/adelson-library", "aria-label" => i["location"]["name"] + " Hours" %>
               <% else %>
-                <%= link_to "Hours", "https://www.library.cornell.edu/libraries/" + i["location"]["hoursCode"], "aria-label" => i["location"]["name"] + " Hours" %>
+                <%= link_to "Hours", "https://" + i["location"]["hoursCode"] + ".library.cornell.edu", "aria-label" => i["location"]["name"] + " Hours" %>
               <% end %>
             <% end %>
           <% end %>


### PR DESCRIPTION
This updates the path to the unit library websites from the availability box, per https://culibrary.atlassian.net/browse/DACCESS-317.

CISER was removed because it is no longer a location in Solr.

I also threw in a small CSS change to improve the spacing of facet values.
