### PR TITLE
DACCESS-486 - Fix for browse#info library holdings by format links

### DIFF
--- a/blacklight-cornell/app/controllers/browse_controller.rb
+++ b/blacklight-cornell/app/controllers/browse_controller.rb
@@ -205,7 +205,7 @@ class BrowseController < ApplicationController
     params[:authq].gsub!('%20', ' ')
 
     # Get Library of Congress local name and format facet for Author and Subject heading
-    if @heading_document.present? && ['Author', 'Subject'].include?(params[:browse_type])
+    if @heading_document.present?
       if params[:browse_type] == 'Author'
         loc_url = get_author_loc_url
       elsif params[:browse_type] == 'Subject'

--- a/blacklight-cornell/app/controllers/browse_controller.rb
+++ b/blacklight-cornell/app/controllers/browse_controller.rb
@@ -199,7 +199,8 @@ class BrowseController < ApplicationController
     }
     query_params[:fq] = "headingTypeDesc:\"#{params[:headingtype]}\"" if params[:headingtype].present?
     solr_response = solr.get 'browse', :params => query_params
-    @heading_document = solr_response['response']['docs'][0]
+    solr_doc = solr_response['response']['docs'][0]
+    @heading_document = solr_doc.present? ? HeadingSolrDocument.new(solr_doc) : nil
 
     params[:authq].gsub!('%20', ' ')
 
@@ -214,9 +215,9 @@ class BrowseController < ApplicationController
       end
 
       @loc_localname = !loc_url.blank? ? loc_url.split('/').last.inspect : ''
-      @formats = get_formats(params[:authq], params[:headingtype])
+      @formats = get_formats(params[:authq])
     else
-      @formats = []
+      @formats = {}
     end
 
     respond_to do |format|
@@ -283,119 +284,23 @@ class BrowseController < ApplicationController
     ''
   end
 
- def get_formats(query,htype)
-    qparam_hash = define_search_fields(query,htype)
-    if qparam_hash.empty?
-      formats = []
+ def get_formats(query)
+    browse_fields = @heading_document.browse_fields
+    if browse_fields.empty?
+      {}
     else
-      solr = RSolr.connect :url => ENV["SOLR_URL"]
-      solr_response = solr.get 'select', :params => {
-                                         :q => qparam_hash[:q],
-                                         :rows => 0,
-                                         :q_row => qparam_hash[:qr],
-                                         :op_row => qparam_hash[:or],
-                                         :search_field_row => qparam_hash[:sfr],
-                                         :mm => 1
-                                        }
+      query = browse_fields.map { |field| "#{field}:\"#{query}\"" }.join(' OR ')
+      solr = RSolr.connect :url => ENV['SOLR_URL']
+      solr_response = solr.get 'select',
+        :params => {
+          :q => query,
+          :rows => 0,
+          :mm => 1
+        }
 
-      formats = solr_response['facet_counts']['facet_fields']['format']
+      format_facet_counts = solr_response['facet_counts']['facet_fields']['format']
+      Hash[*format_facet_counts]
     end
-
-    # uri = "https://digital.library.cornell.edu/catalog.json?utf8=%E2%9C%93&q=#{query}&search_field=all_fields&rows=3"
-    # url = Addressable::URI.parse(URI.escape(uri))
-    # url.normalize
-    # portal_response = JSON.load(open(url.to_s))
-    # if portal_response['response']['pages']['total_count'] > 0
-    #   formats << "Digital Collections"
-    #   formats << portal_response['response']['pages']['total_count']
-    # end
-    f_count = 0
-    tmp_array = []
-    formats.each do |f|
-      if f.class == String
-        tmp_string = pluralize_format(f) + " (" + number_with_delimiter(formats[f_count + 1], :delimiter => ',').to_s + ")"
-        tmp_array << tmp_string
-      end
-      f_count = f_count + 1
-    end
-
-    return tmp_array.sort
-  end
-
-  def pluralize_format(format)
-    case format
-    when "Book"
-      format = "Books"
-    when "Journal/Periodical"
-      format = "Journals/Periodicals"
-    when "Manuscript/Archive"
-      format = "Manuscripts/Archives"
-    when "Map"
-      format = "Maps"
-    when "Musical Score"
-      format = "Musical Scores"
-    when "Non-musical Recording"
-      format = "Non-musical Recordings"
-    when "Video"
-      format = "Videos"
-    when "Computer File"
-      format = "Computer Files"
-    when "Database"
-      format = "Databases"
-    when "Musical Recording"
-      format = "Musical Recordings"
-    when "Thesis"
-      format = "Theses"
-    when "Microform"
-      format = "Microforms"
-    end
-    return format
-  end
-
-  def define_search_fields(query,htype)
-    temp_hash = {}
-    if htype == "Personal Name"
-      temp_hash = {:q => '(((+author_pers_browse:"' + query + '") OR author_pers_browse:"' + query + '") OR ((+subject_pers_browse:"' + query + '") OR subject_pers_browse:"' + query + '"))',
-                   :qr => [query, query],
-                   :or => ["AND", "AND"],
-                   :sfr => ["author_pers_browse", "subject_pers_browse"]}
-    elsif htype == "Corporate Name"
-      temp_hash = {:q => '(((+author_corp_browse:"' + query + '") OR author_corp_browse:"' + query + '") OR ((+subject_corp_browse:"' + query + '") OR subject_corp_browse:"' + query + '"))',
-                   :qr => [query, query],
-                   :or => ["AND", "AND"],
-                   :sfr => ["author_corp_browse", "subject_corp_browse"]}
-    elsif htype ==  "Event"
-      temp_hash = {:q => '(((+author_event_browse:"' + query + '") OR author_event_browse:"' + query + '") OR ((+subject_event_browse:"' + query + '") OR subject_event_browse:"' + query + '"))',
-                   :qr => [query, query],
-                   :or => ["AND", "AND"],
-                   :sfr => ["author_event_browse", "subject_event_browse"]}
-    elsif htype ==  "Chronological Term"
-      temp_hash = {:q => '((+subject_era_browse:"' + query + '") OR subject_era_browse:"' + query + '")',
-                   :qr => [query, query],
-                   :or => ["AND"],
-                   :sfr => ["subject_era_browse"]}
-    elsif htype ==  "Genre/Form Term"
-      temp_hash = {:q => '((+subject_genr_browse:"' + query + '") OR subject_genr_browse:"' + query + '")',
-                   :qr => [query],
-                   :or => ["AND"],
-                   :sfr => ["subject_genr_browse"]}
-    elsif htype ==  "Geographic Name"
-      temp_hash = {:q => '((+subject_geo_browse:"' + query + '") OR subject_geo_browse:"' + query + '")',
-                   :qr => [query],
-                   :or => ["AND"],
-                   :sfr => ["subject_geo_browse"]}
-    elsif htype ==  "Topical Term"
-      temp_hash = {:q => '((+subject_topic_browse:"' + query + '") OR subject_topic_browse:"' + query + '")',
-                   :qr => [query],
-                   :or => ["AND"],
-                   :sfr => ["subject_topic_browse"]}
-    elsif htype ==  "Work"
-      temp_hash = {:q => '((+subject_work_browse:"' + query + '") OR subject_work_browse:"' + query + '")',
-                   :qr => [query],
-                   :or => ["AND"],
-                   :sfr => ["subject_work_browse"]}
-    end
-    return temp_hash
   end
 
   private

--- a/blacklight-cornell/app/helpers/browse_helper.rb
+++ b/blacklight-cornell/app/helpers/browse_helper.rb
@@ -130,32 +130,4 @@ def build_heading_type(heading_type)
   def pluralize_format(format)
     format.split('/').map(&:pluralize).join('/')
   end
-
-  def fa_icon_for_format(format)
-    case format
-    when "Journal/Periodical"
-      'fa-book-open'
-    when "Manuscript/Archive"
-      'fa-archive'
-    when "Map"
-      'fa-globe'
-    when "Non-musical Recording"
-      'fa-headphones'
-    when "Video"
-      'fa-video-camera'
-    when "Computer File"
-      'fa-save'
-    when "Musical Recording"
-      'fa-music'
-    when "Thesis"
-      'fa-file-text-o'
-    when "Microform"
-      'fa-film'
-    when "Miscellaneous"
-      'fa-ellipsis-h'
-    else
-      dasherized_format = format.downcase.gsub(/\s+/, '-')
-      "fa-#{dasherized_format}"
-    end
-  end
 end

--- a/blacklight-cornell/app/helpers/browse_helper.rb
+++ b/blacklight-cornell/app/helpers/browse_helper.rb
@@ -1,28 +1,5 @@
 module BrowseHelper
 
-  def search_field(heading_type)
-    case heading_type
-    when 'Personal Name'
-      'pers'
-    when 'Corporate Name'
-      'corp'
-    when 'Event'
-      'event'
-    when 'Geographic Name'
-      'geo'
-    when 'Chronological Term'
-      'era'
-    when 'Genre/Form Term'
-      'genr'
-    when 'Topical Term'
-      'topic'
-    when 'Work'
-      'work'
-    else
-      'all_fields'
-    end
-  end
-
 def browse_uri_encode (link_url)
     link_url = link_url.gsub('&','%26')
     link_url = link_url.gsub('"','%22')
@@ -131,75 +108,54 @@ def build_heading_type(heading_type)
     return html.html_safe   
  end
 
-  # TODO: Review generated search fields in search links. author_work_browse, for example, is not a valid search field.
-  def build_search_link(format_type, encoded_heading, search_type)
-    if search_type == "pers" || search_type == "corp" || search_type == "event"
-      the_search_field = 'search_field_row[]=author_' + search_type + '_browse&search_field_row[]=subject_' + search_type + '_browse'
-      return format_the_formats(format_type, encoded_heading, the_search_field, "OR")
-    else
-      the_search_field = 'search_field_row[]=subject_' + search_type + '_browse&search_field_row[]=author_' + search_type + '_browse'
-      return format_the_formats(format_type, encoded_heading, the_search_field, "NOT")    
-    end
-    return ""#%2F
+  def build_search_link(format, f_count)
+    browse_field_count = @heading_document.browse_fields.count
+    boolean_row = {}
+    (browse_field_count - 1).times { |i| boolean_row[i + 1] = 'OR' }
+    search_params = {
+      advanced_query: 'yes',
+      search_field: 'advanced',
+      search_field_row: @heading_document.browse_fields,
+      boolean_row: boolean_row,
+      op_row: ['AND'] * browse_field_count,
+      q_row: [@heading_document['heading']] * browse_field_count,
+      "f[format]": [format]
+    }
+    
+    format_with_count = "#{pluralize_format(format)} (#{number_with_delimiter(f_count)})"
+    link_id = "facet_link_#{format.downcase.gsub(/[\/\-\s]/, '_')}"
+    link_to format_with_count, search_catalog_path(search_params).html_safe, id: link_id
   end
-  
-  def format_the_formats(f_type, encoded_heading, the_search_field, bool)
-    html = ""    
-    f = f_type.split(" (")[0]
-    case f
-    when "Books"
-      html = '<i class="fa fa-book"></i>'
-      html += '<a id="facet_link_book" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Book&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Journals/Periodicals"
-      html = '<i class="fa fa-book-open"></i>'
-      html += '<a id="facet_link_journal_periodical" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Journal/Periodical&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Manuscripts/Archives"
-      html = '<i class="fa fa-archive"></i>'
-      html += '<a id="facet_link_manuscript_archive" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Manuscript/Archive&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Maps"
-      html = '<i class="fa fa-globe"></i>'
-      html += '<a id="facet_link_map" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Map&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Musical Scores"
-      html = '<i class="fa-musical-score"></i>'
-      html += '<a id="facet_link_musical_score" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Musical%20Score&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Non-musical Recordings"
-      html = '<i class="fa fa-headphones"></i>'
-      html += '<a id="facet_link_non_musical_recording" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Non-musical%20Recording&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Videos"
-      html = '<i class="fa fa-video-camera"></i>'
-      html += '<a id="facet_link_video" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Video&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Computer Files"
-      html = '<i class="fa fa-save"></i>'
-      html += '<a id="facet_link_computer_file" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Computer%20File&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Databases"
-      html = '<i class="fa fa-database"></i>'
-      html += '<a id="facet_link_database" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Database&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Musical Recordings"
-      html = '<i class="fa fa-music"></i>'
-      html += '<a id="facet_link_musical_recording" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Musical%20Recording&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Theses"
-      html = '<i class="fa fa-file-text-o"></i>'
-      html += '<a id="facet_link_thesis" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Thesis&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
-    when "Microforms"
-      html = '<i class="fa fa-film"></i>'
-      html += '<a id="facet_link_microform" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Microform&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
+
+  def pluralize_format(format)
+    format.split('/').map(&:pluralize).join('/')
+  end
+
+  def fa_icon_for_format(format)
+    case format
+    when "Journal/Periodical"
+      'fa-book-open'
+    when "Manuscript/Archive"
+      'fa-archive'
+    when "Map"
+      'fa-globe'
+    when "Non-musical Recording"
+      'fa-headphones'
+    when "Video"
+      'fa-video-camera'
+    when "Computer File"
+      'fa-save'
+    when "Musical Recording"
+      'fa-music'
+    when "Thesis"
+      'fa-file-text-o'
+    when "Microform"
+      'fa-film'
     when "Miscellaneous"
-      html = '<i class="fa fa-ellipsis-h"></i>'
-      html += '<a id="facet_link_miscellaneous" href="/?advanced_query=yes&boolean_row[1]=' + bool + '&f[format][]=Miscellaneous&op_row[]=AND&op_row[]=AND'
-      html += '&q_row[]=' + encoded_heading + '&q_row[]=' + encoded_heading + '&search_field=advanced&' + the_search_field + '">' + f_type + '</a>'
+      'fa-ellipsis-h'
+    else
+      dasherized_format = format.downcase.gsub(/\s+/, '-')
+      "fa-#{dasherized_format}"
     end
-    return html.html_safe
   end
 end

--- a/blacklight-cornell/app/models/heading_solr_document.rb
+++ b/blacklight-cornell/app/models/heading_solr_document.rb
@@ -1,0 +1,41 @@
+class HeadingSolrDocument
+  include Blacklight::Solr::Document
+
+  def type
+    type_for_desc(fetch('headingTypeDesc', ''))
+  end
+
+  def type_for_desc(heading_type_desc)
+    case heading_type_desc
+    when 'Personal Name'
+      'pers'
+    when 'Corporate Name'
+      'corp'
+    when 'Event'
+      'event'
+    when 'Geographic Name'
+      'geo'
+    when 'Chronological Term'
+      'era'
+    when 'Genre/Form Term'
+      'genr'
+    when 'Topical Term'
+      'topic'
+    else
+      # No headingTypeDesc for authortitle headings
+      'work'
+    end
+  end
+
+  def browse_fields
+    return [] unless type.present?
+
+    browse_fields = ["subject_#{type}_browse"]
+    if ['pers', 'corp', 'event'].include?(type)
+      browse_fields << "author_#{type}_browse"
+    elsif type == 'work'
+      browse_fields << 'authortitle_browse'
+    end
+    browse_fields
+  end
+end

--- a/blacklight-cornell/app/views/browse/_holdings.html.erb
+++ b/blacklight-cornell/app/views/browse/_holdings.html.erb
@@ -20,7 +20,7 @@
       <% if works['worksBy'].present? %>
         <li>
           Total Works By:
-          <%= link_to "/?q=\"#{encoded_heading}\"&search_field=author_#{search_field(@heading_document['headingTypeDesc'])}_browse" do %>
+          <%= link_to "/?q=\"#{encoded_heading}\"&search_field=author_#{@heading_document.type}_browse" do %>
             <%= pluralize(number_with_delimiter(works['worksBy']), 'Title') %>
           <% end %>
         </li>
@@ -28,7 +28,7 @@
       <% if works['worksAbout'].present? %>
         <li>
           Total Works About:
-          <%= link_to "/?q=\"#{encoded_heading}\"&search_field=subject_#{search_field(@heading_document['headingTypeDesc'] || 'Work')}_browse" do %>
+          <%= link_to "/?q=\"#{encoded_heading}\"&search_field=subject_#{@heading_document.type}_browse" do %>
             <%= pluralize(number_with_delimiter(works['worksAbout']), 'Title') %>
           <% end %>
         </li>
@@ -36,9 +36,9 @@
       <li style='text-align center'>
         <div style='width:100%;border-bottom: solid 1px #dcdcdc'></div>
       </li>
-      <% @formats.each do |f| %>
+      <% @formats.each do |format, f_count| %>
         <li>
-          <%= build_search_link(f, encoded_heading, search_field(@heading_document['headingTypeDesc']))%>
+          <i class="fa <%= fa_icon_for_format(format) %>"></i><%= build_search_link(format, f_count) %>
         </li>
       <% end %>
     </ul>

--- a/blacklight-cornell/app/views/browse/_holdings.html.erb
+++ b/blacklight-cornell/app/views/browse/_holdings.html.erb
@@ -38,7 +38,7 @@
       </li>
       <% @formats.each do |format, f_count| %>
         <li>
-          <i class="fa <%= fa_icon_for_format(format) %>"></i><%= build_search_link(format, f_count) %>
+          <i class="fa fa-<%= DisplayHelper::FORMAT_MAPPINGS[format] %>"></i><%= build_search_link(format, f_count) %>
         </li>
       <% end %>
     </ul>

--- a/blacklight-cornell/app/views/browse/_reference_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_reference_info.html.erb
@@ -29,7 +29,7 @@
         <% if headingInfo["worksBy"].present? %>
           <span class="author-works">
             Works by:
-            <%= link_to '/?q="' + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + '"&search_field=author_' + search_field(headingInfo["headingTypeDesc"]) + '_browse' do %>
+            <%= link_to '/?q="' + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + '"&search_field=author_' + @heading_document.type_for_desc(headingInfo["headingTypeDesc"]) + '_browse' do %>
               <%= headingInfo["worksBy"] %>
             <% end %>
           </span>
@@ -37,7 +37,7 @@
         <% if headingInfo["worksAbout"].present? %>
           <span class="author-works">
             Works about:
-            <%= link_to '/?q="' + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + '"&search_field=subject_' + search_field(headingInfo["headingTypeDesc"]) + '_browse' do %>
+            <%= link_to '/?q="' + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + '"&search_field=subject_' + @heading_document.type_for_desc(headingInfo["headingTypeDesc"]) + '_browse' do %>
               <%= headingInfo["worksAbout"] %>
             <% end %>
           </span>

--- a/blacklight-cornell/spec/helpers/browse_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/browse_helper_spec.rb
@@ -107,22 +107,4 @@ describe BrowseHelper do
       expect(helper.pluralize_format('Miscellaneous')).to eq('Miscellaneous')
     end
   end
-
-  describe '#fa_icon_for_format' do
-    it 'returns expected fontawesome icon class' do
-      expect(helper.fa_icon_for_format('Book')).to eq('fa-book')
-      expect(helper.fa_icon_for_format('Journal/Periodical')).to eq('fa-book-open')
-      expect(helper.fa_icon_for_format('Manuscript/Archive')).to eq('fa-archive')
-      expect(helper.fa_icon_for_format('Map')).to eq('fa-globe')
-      expect(helper.fa_icon_for_format('Musical Score')).to eq('fa-musical-score')
-      expect(helper.fa_icon_for_format('Non-musical Recording')).to eq('fa-headphones')
-      expect(helper.fa_icon_for_format('Video')).to eq('fa-video-camera')
-      expect(helper.fa_icon_for_format('Computer File')).to eq('fa-save')
-      expect(helper.fa_icon_for_format('Database')).to eq('fa-database')
-      expect(helper.fa_icon_for_format('Musical Recording')).to eq('fa-music')
-      expect(helper.fa_icon_for_format('Thesis')).to eq('fa-file-text-o')
-      expect(helper.fa_icon_for_format('Microform')).to eq('fa-film')
-      expect(helper.fa_icon_for_format('Miscellaneous')).to eq('fa-ellipsis-h')
-    end
-  end
 end

--- a/blacklight-cornell/spec/helpers/browse_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/browse_helper_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+describe BrowseHelper do
+  describe '#build_search_link' do
+    before do
+      assign(:heading_document, HeadingSolrDocument.new(solr_doc_response))
+    end
+
+      context 'personal name heading type' do
+        let(:solr_doc_response) {
+          { 'headingTypeDesc' => 'Personal Name', 'heading' => 'Beethoven, Ludwig van, 1770-1827.' }
+        }
+
+        it 'returns catalog search link' do
+          expect(helper.build_search_link('Musical Recording', 20)).
+            to eq(
+              '<a id="facet_link_musical_recording" href="/catalog'\
+              '?advanced_query=yes'\
+              '&boolean_row%5B1%5D=OR'\
+              '&f%5Bformat%5D%5B%5D=Musical+Recording'\
+              '&op_row%5B%5D=AND&op_row%5B%5D=AND'\
+              '&q_row%5B%5D=Beethoven%2C+Ludwig+van%2C+1770-1827.&q_row%5B%5D=Beethoven%2C+Ludwig+van%2C+1770-1827.'\
+              '&search_field=advanced'\
+              '&search_field_row%5B%5D=subject_pers_browse&search_field_row%5B%5D=author_pers_browse'\
+              '">Musical Recordings (20)</a>'
+            )
+        end
+      end
+
+      context 'geographic name heading type' do
+        let(:solr_doc_response) {
+          { 'headingTypeDesc' => 'Topical Term', 'heading' => 'House buying > Handbooks, manuals, etc.' }
+        }
+
+        it 'returns catalog search link' do
+          expect(helper.build_search_link('Manuscript/Archive', 4)).
+            to eq(
+              '<a id="facet_link_manuscript_archive" href="/catalog'\
+              '?advanced_query=yes'\
+              '&f%5Bformat%5D%5B%5D=Manuscript%2FArchive'\
+              '&op_row%5B%5D=AND'\
+              '&q_row%5B%5D=House+buying+%3E+Handbooks%2C+manuals%2C+etc.'\
+              '&search_field=advanced'\
+              '&search_field_row%5B%5D=subject_topic_browse'\
+              '">Manuscripts/Archives (4)</a>'
+            )
+        end
+
+      context 'subject heading, work heading type' do
+        let(:solr_doc_response) {
+          { 'headingTypeDesc' => 'Work', 'heading' => 'Shakespeare, William, 1564-1616. | All\'s well that ends well' }
+        }
+
+        it 'returns catalog search link' do
+          expect(helper.build_search_link('Book', 46)).
+            to eq(
+              '<a id="facet_link_book" href="/catalog'\
+              '?advanced_query=yes'\
+              '&boolean_row%5B1%5D=OR'\
+              '&f%5Bformat%5D%5B%5D=Book'\
+              '&op_row%5B%5D=AND&op_row%5B%5D=AND'\
+              '&q_row%5B%5D=Shakespeare%2C+William%2C+1564-1616.+%7C+All%27s+well+that+ends+well&q_row%5B%5D=Shakespeare%2C+William%2C+1564-1616.+%7C+All%27s+well+that+ends+well'\
+              '&search_field=advanced'\
+              '&search_field_row%5B%5D=subject_work_browse&search_field_row%5B%5D=authortitle_browse'\
+              '">Books (46)</a>'
+            )
+        end
+      end
+
+      context 'authortitle heading' do
+        let(:solr_doc_response) {
+          { 'heading' => 'Shakespeare, William, 1564-1616. | All\'s well that ends well' }
+        }
+
+        it 'returns catalog search link' do
+          expect(helper.build_search_link('Book', 46)).
+            to eq(
+              '<a id="facet_link_book" href="/catalog'\
+              '?advanced_query=yes'\
+              '&boolean_row%5B1%5D=OR'\
+              '&f%5Bformat%5D%5B%5D=Book'\
+              '&op_row%5B%5D=AND&op_row%5B%5D=AND'\
+              '&q_row%5B%5D=Shakespeare%2C+William%2C+1564-1616.+%7C+All%27s+well+that+ends+well&q_row%5B%5D=Shakespeare%2C+William%2C+1564-1616.+%7C+All%27s+well+that+ends+well'\
+              '&search_field=advanced'\
+              '&search_field_row%5B%5D=subject_work_browse&search_field_row%5B%5D=authortitle_browse'\
+              '">Books (46)</a>'
+            )
+        end
+      end
+    end
+  end
+
+  describe '#pluralize_format' do
+    it 'returns pluralized format' do
+      expect(helper.pluralize_format('Book')).to eq('Books')
+      expect(helper.pluralize_format('Journal/Periodical')).to eq('Journals/Periodicals')
+      expect(helper.pluralize_format('Manuscript/Archive')).to eq('Manuscripts/Archives')
+      expect(helper.pluralize_format('Map')).to eq('Maps')
+      expect(helper.pluralize_format('Musical Score')).to eq('Musical Scores')
+      expect(helper.pluralize_format('Non-musical Recording')).to eq('Non-musical Recordings')
+      expect(helper.pluralize_format('Video')).to eq('Videos')
+      expect(helper.pluralize_format('Computer File')).to eq('Computer Files')
+      expect(helper.pluralize_format('Database')).to eq('Databases')
+      expect(helper.pluralize_format('Musical Recording')).to eq('Musical Recordings')
+      expect(helper.pluralize_format('Thesis')).to eq('Theses')
+      expect(helper.pluralize_format('Microform')).to eq('Microforms')
+      expect(helper.pluralize_format('Miscellaneous')).to eq('Miscellaneous')
+    end
+  end
+
+  describe '#fa_icon_for_format' do
+    it 'returns expected fontawesome icon class' do
+      expect(helper.fa_icon_for_format('Book')).to eq('fa-book')
+      expect(helper.fa_icon_for_format('Journal/Periodical')).to eq('fa-book-open')
+      expect(helper.fa_icon_for_format('Manuscript/Archive')).to eq('fa-archive')
+      expect(helper.fa_icon_for_format('Map')).to eq('fa-globe')
+      expect(helper.fa_icon_for_format('Musical Score')).to eq('fa-musical-score')
+      expect(helper.fa_icon_for_format('Non-musical Recording')).to eq('fa-headphones')
+      expect(helper.fa_icon_for_format('Video')).to eq('fa-video-camera')
+      expect(helper.fa_icon_for_format('Computer File')).to eq('fa-save')
+      expect(helper.fa_icon_for_format('Database')).to eq('fa-database')
+      expect(helper.fa_icon_for_format('Musical Recording')).to eq('fa-music')
+      expect(helper.fa_icon_for_format('Thesis')).to eq('fa-file-text-o')
+      expect(helper.fa_icon_for_format('Microform')).to eq('fa-film')
+      expect(helper.fa_icon_for_format('Miscellaneous')).to eq('fa-ellipsis-h')
+    end
+  end
+end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-486 - Library holding format counts on browse info pages use invalid search fields on some subject pages
- Author-Title browse pages now include Library Holdings search links by format
- Subject browse pages (when heading type is geo, era, genr, topic, work) now have correct library holdings by format links
- Subject browse pages when heading type is work now display library holding counts by format that include matching authortitle_browse records
- Related cleanup