### PR TITLE
Comment out failing rmc hours tests, remove test containers at end of jenkins scripts

### DIFF
--- a/blacklight-cornell/features/catalog_search/item_view.feature
+++ b/blacklight-cornell/features/catalog_search/item_view.feature
@@ -705,22 +705,24 @@ Feature: Item view
     # Commenting out for Folio migration
     #Then I should see the label 'Request item'
 
-  @hours-page
-  @on-site-use
-  @all_item_view
-  Scenario: View an items holdings, and have pointer to RMC help page.
-    Given I request the item view for 2083253
-    # Temporary change for Covid-19: added 'not' to the following line.
-    Then I should see the label 'On-site use'
-    And it should have link "Hours" with value "https://rmc.library.cornell.edu"
+  # Commenting these tests out for now because RMC hours are not actually displaying on prod
+  # We'll also want to change the link to "rare" instead of "rmc" for these items
+  # @hours-page
+  # @on-site-use
+  # @all_item_view
+  # Scenario: View an items holdings, and have pointer to RMC help page.
+  #   Given I request the item view for 2083253
+  #   # Temporary change for Covid-19: added 'not' to the following line.
+  #   Then I should see the label 'On-site use'
+  #   And it should have link "Hours" with value "https://rmc.library.cornell.edu"
 
-  @hours-page
-  @on-site-use
-  @all_item_view
-  Scenario: View an hotel items holdings, and have pointer to ILR help page.
-    Given I request the item view for 330333
-    Then I should see the label 'On-site use'
-    And it should have link "Hours" with value "https://rmc.library.cornell.edu"
+  # @hours-page
+  # @on-site-use
+  # @all_item_view
+  # Scenario: View an hotel items holdings, and have pointer to ILR help page.
+  #   Given I request the item view for 330333
+  #   Then I should see the label 'On-site use'
+  #   And it should have link "Hours" with value "https://rmc.library.cornell.edu"
 
 # item view links to call number browse
 #  @all_item_view

--- a/blacklight-cornell/features/catalog_search/item_view.feature
+++ b/blacklight-cornell/features/catalog_search/item_view.feature
@@ -712,7 +712,7 @@ Feature: Item view
     Given I request the item view for 2083253
     # Temporary change for Covid-19: added 'not' to the following line.
     Then I should see the label 'On-site use'
-    And it should have link "Hours" with value "https://www.library.cornell.edu/libraries/rmc"
+    And it should have link "Hours" with value "https://rmc.library.cornell.edu"
 
   @hours-page
   @on-site-use
@@ -720,7 +720,7 @@ Feature: Item view
   Scenario: View an hotel items holdings, and have pointer to ILR help page.
     Given I request the item view for 330333
     Then I should see the label 'On-site use'
-    And it should have link "Hours" with value "https://www.library.cornell.edu/libraries/rmc"
+    And it should have link "Hours" with value "https://rmc.library.cornell.edu"
 
 # item view links to call number browse
 #  @all_item_view

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
         // use this version for normal situations
         stage("Cucumber tests") {
             steps {
+                echo "The branch is ${env.GIT_BRANCH}"
                 echo "Running Cucumber tests with ${params.NUM_PROCESSES} processes"
                 timeout(90) {
                     wrap([$class: 'Xvfb', additionalOptions: '', assignedLabels: '', autoDisplayName: true, debug: true, displayNameOffset: 0, installationName: 'default', parallelBuild: true, screen: '1024x758x24', timeout: 25]) {

--- a/jenkins/cucumber-features.sh
+++ b/jenkins/cucumber-features.sh
@@ -14,5 +14,6 @@ export RAILS_ENV_FILE=./container_env_test.env
 export COVERAGE_PATH=${JENKINS_WORKSPACE}/blacklight-cornell/coverage
 project_name="container-discovery-test-${TEST_ID}"
 echo "Cucumber tests for ${project_name}"
-./build_test.sh
+docker compose -f docker-compose-test.yaml build
 docker compose -p $project_name -f docker-compose-test.yaml up --exit-code-from webapp
+docker compose -p $project_name -f docker-compose-test.yaml down

--- a/jenkins/rspec.sh
+++ b/jenkins/rspec.sh
@@ -15,3 +15,4 @@ project_name="container-discovery-test-${TEST_ID}"
 echo "RSpec tests for ${project_name}"
 export USE_RSPEC=1
 docker compose -p $project_name -f docker-compose-test.yaml up --exit-code-from webapp
+docker compose -p $project_name -f docker-compose-test.yaml down


### PR DESCRIPTION
Includes:

- Commenting out failing rmc hours tests after chatting with Melissa about current state of rmc hours display
- Update container test scripts to simplify test container builds on jenkins and remove containers at end