### PR TITLE
DACCESS-541: add search tip for databases streaming video

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss
@@ -162,13 +162,24 @@ h3 { font-size: 20px; line-height: 1.5em;}
 	  font-size: 20px;
 	}
 	.heads-up {
-	  font-size: 16px;
+	  font-size: 1.1rem;
 	  margin-bottom:.5em;
 	  font-weight: bold;
 	  padding:0;
 	}
 	i {
-	  color: $cornell-primary
+	  color: $cornell-primary;
+	  margin-right: .25rem;
+	}
+}
+.highlight-box.highlight-box-tan {
+	background: $light-tan;
+}
+.databases-subject {
+	.highlight-box {
+		i {
+			color: $cornell-primary
+		}
 	}
 }
 .highlight-box.search-more {

--- a/blacklight-cornell/app/views/databases/subject.html.erb
+++ b/blacklight-cornell/app/views/databases/subject.html.erb
@@ -12,6 +12,13 @@
     <h2>
       <%= params[:q] %>
     </h2>
+    <% if params[:q] == "Streaming Video" %>
+      <div class="highlight-box highlight-box-tan">
+        <div class="heads-up"><i class="fa fa-info-circle" aria-hidden="true"></i>How to find streaming video</div>
+        <p class="mb-0"><a href="/">Search the catalog</a> for streaming content. Need help? Check out our <a href="https://guides.library.cornell.edu/hybridOnlineTeaching/streaming">help guide</a>.</p>
+      </div>
+      </div>
+    <% end %>
   </div>
 </div>
 <% if @subjectCore.present? %>
@@ -28,7 +35,7 @@
     <%= render 'database', :response => @subject %>
   </div>
 <% else %>
-  <div class="resources">
+  <div class="resources container">
     <%= render 'database', :response => @subject %>
   </div>
 <% end %>

--- a/blacklight-cornell/app/views/databases/subject.html.erb
+++ b/blacklight-cornell/app/views/databases/subject.html.erb
@@ -15,7 +15,7 @@
     <% if params[:q] == "Streaming Video" %>
       <div class="highlight-box highlight-box-tan">
         <div class="heads-up"><i class="fa fa-info-circle" aria-hidden="true"></i>How to find streaming video</div>
-        <p class="mb-0"><a href="/">Search the catalog</a> for streaming content. Need help? Check out our <a href="https://guides.library.cornell.edu/hybridOnlineTeaching/streaming">help guide</a>.</p>
+        <p class="mb-0"><a href="/" onclick="_paq.push(['trackEvent', 'databases', 'streaming_catalog_search']);">Search the catalog</a> for streaming content. Need help? Check out our <a href="https://guides.library.cornell.edu/hybridOnlineTeaching/streaming" onclick="_paq.push(['trackEvent', 'databases', 'streaming_libguide']);">help guide</a>.</p>
       </div>
       </div>
     <% end %>


### PR DESCRIPTION
Sally requested a link to the streaming video libguide — "The purpose is to steer users to searching the catalog before going to a streaming vendor such as Kanopy and making a purchase request for something we already have from another vendor." 

https://culibrary.atlassian.net/browse/DACCESS-541

I added a link to search the catalog and modified her suggested wording. I used the `highlight-box` element, which is used in other areas of the catalog (best bet, "search more" at end of results).

I also added a `container` class to fix the alignment of the resources below the heading (they were wider than the rest of the content; screenshot does not show the alignment fix).

![Screenshot 2025-04-22 at 10 30 25 AM](https://github.com/user-attachments/assets/cf3e398b-b9a0-4152-8e12-e9d1818fed27)