### PR TITLE
DACCESS-223: single search tooltip should be read by screenreaders

### DIFF
--- a/blacklight-cornell/app/views/single_search/index.html.erb
+++ b/blacklight-cornell/app/views/single_search/index.html.erb
@@ -22,7 +22,7 @@
       <div class="card card-well">
         <div class="card-body">
           <div class="search-info">
-            <a href="#" class="d-none d-sm-block float-right" data-placement="bottom" data-toggle="tooltip" title="Search the Library Catalog, Articles and Full Text, and more. WorldCat is available through the Libraries Worldwide link in the search results.">
+            <a href="#" class="float-right" data-placement="bottom" data-toggle="tooltip" title="Search the Library Catalog, Articles and Full Text, and more. WorldCat is available through the Libraries Worldwide link in the search results.">
               <i class="fa fa-info-circle" aria-hidden="true"></i>
               About this search
             </a>


### PR DESCRIPTION
Removing the hiding classes fixed the readability by VoiceOver. I had originally hidden this tooltip for mobile because I thought it couldn't be accessed on the mobile device, I guess? But I confirmed that it can be clicked/displayed on mobile.