### PR TITLE
DACCESS-290 - Add inclusive language facet to advanced search form

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_search-results.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_search-results.scss
@@ -172,6 +172,10 @@ body.book_bags-index #documents .document {
 		display: inline;
 		color: white;
 		margin: 0 .5em; }
+
+  .constraints-container {
+    display: block;
+  }
 }
 
 // Did you mean

--- a/blacklight-cornell/app/components/advanced_facet_field_checkboxes_component.rb
+++ b/blacklight-cornell/app/components/advanced_facet_field_checkboxes_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Custom FacetFieldCheckboxesComponent to prefill facet checkboxes with f_inclusive values in advanced search form
+# Can remove this in blacklight >= v8.4.0: https://github.com/projectblacklight/blacklight/pull/3278/files
+class AdvancedFacetFieldCheckboxesComponent < Blacklight::FacetFieldCheckboxesComponent
+  def presenters
+    return [] unless @facet_field.paginator
+
+    return to_enum(:presenters) unless block_given?
+
+    @facet_field.paginator.items.each do |item|
+      yield Blacklight::FacetCheckboxItemPresenter.new(item, @facet_field.facet_field, helpers, @facet_field.key, @facet_field.search_state)
+    end
+  end
+end

--- a/blacklight-cornell/app/components/blacklight/facet_field_inclusive_constraint_component.html.erb
+++ b/blacklight-cornell/app/components/blacklight/facet_field_inclusive_constraint_component.html.erb
@@ -1,0 +1,7 @@
+<%# Override component from blacklight to use h4 instead of h5 %>
+<div class="inclusive_or card card-body bg-light mb-3">
+  <h4><%= t('blacklight.advanced_search.any_of') %></h4>
+  <ul class="list-unstyled facet-values">
+    <%= helpers.render(Blacklight::FacetItemComponent.with_collection(presenters.to_a)) %>
+  </ul>
+</div>

--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -200,7 +200,7 @@ class CatalogController < ApplicationController
     }, :show => true, :include_in_advanced_search => false, if: :has_search_parameters?
 
     config.add_facet_field 'workid_facet', :label => 'Work', :show => false
-    config.add_facet_field 'language_facet', :label => 'Language', :limit => 5 , :show => true
+    config.add_facet_field 'language_facet', :label => 'Language', :limit => 5 , :show => true, :include_in_advanced_search => true
     config.add_facet_field 'fast_topic_facet', :label => 'Subject', :limit => 5, if: :has_search_parameters?
     config.add_facet_field 'fast_geo_facet', :label => 'Subject: Region', :limit => 5, if: :has_search_parameters?
     config.add_facet_field 'fast_era_facet', :label => 'Subject: Era', :limit => 5, if: :has_search_parameters?

--- a/blacklight-cornell/app/helpers/cornell_params_helper.rb
+++ b/blacklight-cornell/app/helpers/cornell_params_helper.rb
@@ -1,49 +1,29 @@
 module CornellParamsHelper
-    def removeBlanks(my_params = params || {} )
-       testQRow = [] #my_params[:q_row]
-       testOpRow = []
-       testSFRow = []
-       testBRow = []
-       for i in 0..my_params[:q_row].count - 1
-          if my_params[:q_row][i] != '' and !my_params[:q_row][i].nil?
-             testQRow << my_params[:q_row][i]
-             testOpRow << my_params[:op_row][i]
-             testSFRow << my_params[:search_field_row][i]
-          end
-       end
-       hasNonBlankcount = 0
-       for i in 0..my_params[:q_row].count - 1
-          if my_params[:q_row][i].blank? or my_params[:q_row][i].nil?
-          #  if i == 0
-          #    next
-          #  end
-          #  if i == my_params[:q_row].count - 1
-            next
-          #  end
-          else
-            hasNonBlankcount = hasNonBlankcount + 1
-            if i == my_params[:q_row].count - 1 and  hasNonBlankcount > 1
-                if !my_params[:boolean_row][i.to_s.to_sym].nil?
-                testBRow << my_params[:boolean_row][i.to_s.to_sym]
-                end
-            end
-            if i < my_params[:q_row].count - 1 #and (hasNonBlankcount > 1 and my_params[:q_row][i + 1].blank?)
-              if my_params[:boolean_row].nil?
-                my_params[:boolean_row] = {"1" => "AND"}
-              else
-                if !my_params[:boolean_row][i.to_s.to_sym].nil?
-                testBRow << my_params[:boolean_row][i.to_s.to_sym]
-                end
-              end
-            end
-          end
-       end
-        my_params[:q_row] = testQRow
-        my_params[:op_row] = testOpRow
-        my_params[:search_field_row] = testSFRow
-        my_params[:boolean_row] = testBRow
-       return my_params
-     end
+  DEFAULT_BOOLEAN = 'AND'
+  DEFAULT_OP = 'AND'
+  DEFAULT_SEARCH_FIELD = 'all_fields'
+
+  # TODO: Similar to SearchBuilder#remove_blank_rows - can this be DRY-ed up?
+  def remove_blank_rows(my_params = params || {})
+    cleaned_params = { q_row: [], op_row: [], search_field_row: [], boolean_row: {} }
+    row_count = my_params[:q_row].count
+    row_count.times do |i|
+      if my_params[:q_row][i].strip.present?
+        cleaned_params[:q_row] << my_params[:q_row][i]
+        cleaned_params[:op_row] << (my_params.fetch(:op_row, [])[i] || DEFAULT_OP)
+        cleaned_params[:search_field_row] << (my_params.fetch(:search_field_row, [])[i] || DEFAULT_SEARCH_FIELD)
+      end
+
+      # Don't add last bool in boolean_row
+      if cleaned_params[:q_row].present? && my_params[:q_row][i + 1].present?
+        old_boolean_row_key = (i + 1).to_s
+        cleaned_boolean_row_key = cleaned_params[:q_row].count.to_s
+        cleaned_params[:boolean_row][cleaned_boolean_row_key] = (my_params.dig(:boolean_row, old_boolean_row_key) || DEFAULT_BOOLEAN)
+      end
+    end
+
+    my_params.merge(cleaned_params)
+  end
 
  def getCallNos(doc)
    require 'json'
@@ -191,364 +171,57 @@ end
     content.html_safe
   end
 
-  def render_constraints_query(my_params = params)
-  if (@advanced_query.nil? || @advanced_query.keyword_queries.empty? )
-    return  super(my_params)
-  else
-    content = ""
-    @advanced_query.keyword_queries.each_pair do |field, query|
-      label = search_field_def_for_key(field)[:label]
-      if query.include?('%26')
-        query.gsub!('%26','&')
-      end
-      content << render_constraint_element(
-        label, query,
-        :remove =>
-          search_facet_catalog_path(remove_advanced_keyword_query(field,my_params))
-      )
-    end
-    if (@advanced_query.keyword_op == "OR" &&
-        @advanced_query.keyword_queries.length > 1)
-      content = '<span class="inclusive_or appliedFilter">' + '<span class="operator">Any of:</span>' + content + '</span>'
-    end
-    return content.html_safe
-  end
-
-end
-
 def deep_copy(o)
   Marshal.load(Marshal.dump(o))
 end
 
-
 def render_advanced_constraints_query(params)
+  return render_constraints(params) if params[:q_row].blank?
+
   # Create deep copy of params to not alter original search params hash
   my_params = params.present? ? params.deep_dup : {}
-  if !my_params[:q_row].nil?
-     my_params = removeBlanks(my_params)
+  my_params = remove_blank_rows(my_params)
 
-  end
-  if my_params[:search_field] == 'advanced'
- #   my_params.delete(:q)
-  end
-# my_params[:q] = ''
-#  my_params[:show_query] = ''
-  if ( my_params["q_row"].nil? and ( my_params["q"].nil? || my_params["q"].blank?))
-    content = ""
-    content << render_advanced_constraints_filters(my_params)
-    return content.html_safe
-  else
-    if my_params[:q_row].nil?
-      content = ""
-      content << render_constraints(my_params)
-      return content.html_safe
-    end
-    if my_params[:q_row].count == 1
-      my_params[:search_field] = my_params[:search_field_row][0]
-      my_params[:q] = my_params[:q_row][0]
-      hold_q_row = my_params[:q_row][0]
-      hold_search_field_row = my_params[:search_field_row][0]
-      hold_oprow = my_params[:op_row][0]
-      my_params.delete("advanced_query")
-      my_params.delete("q_row")
-      my_params.delete("op_row")
-      my_params.delete(:search_field_row)
-      my_params.delete(:show_query)
-      my_params.delete(:y)
-      my_params.delete(:sort)
-      my_params.delete(:search_field)
- #     my_params.delete(:boolean_row)
+  # Treat single row as a simple search
+  if my_params[:q_row].count == 1
+    # Set simple search params
+    my_params[:search_field] = my_params[:search_field_row][0]
+    my_params[:q] = my_params[:q_row][0]
 
-      my_params[:search_field] = hold_search_field_row
-      content = ""
-      content << render_constraints(my_params)
-      my_params[:q_row] = []
-      my_params[:search_field_row] = []
-      my_params[:op_row] = []
-      my_params[:q_row][0] = hold_q_row
-      my_params[:search_field_row][0] = hold_search_field_row
-      my_params[:op_row][0] = hold_oprow
- #     my_params[:boolean_row] = {"1" => "AND"}
-      return content.html_safe
-    end
-    if my_params[:boolean_row] == {}
-  #   my_params[:boolean_row] = {"1" => "AND"}
-    end
-    labels = []
-    values = []
-    q_parts = []
-    new_q_parts = []
-    equalsign = []
-    ampersand = []
-    q_string = my_params["q"]
-    content = ""
-    test = ""
-#      if (@advanced_query.keyword_queries.count == 2)
-    facetparams = ""
-    if (my_params[:f].present?)
-      # With Rails 5 my_params[:f].count throws an error because the paras are now an object.
-      # Commenting the block out since it doesn't  appear to do anything. If needed, the error
-      # can be fixed this way: my_params.to_h[:f].count > 1
-      # if(my_params[:f].count > 1)
-      # end
-      start1 = "f["
-      next1 = ""
-      count = 0
-      my_params[:f].each do |key, value|
-         next1 = ""
-         next2 = ""
-         start2 = start1 + key + "][]="
-         value.each do |v|
-           next1 =  next1 + start2 + v + "&"
-     #      next2 =  next2 + start2 + v.gsub!('&','%26')
-         end
-         facetparams = facetparams + next1
-      end
-    else
-      facetparams = ""
-    end
-    if !facetparams.nil?
-    test = facetparams.sub!('Kroch Library Rare & Manuscripts', 'Kroch Library Rare %26 Manuscripts')
-    if !test.nil?
-      facetparams = test
-    end
-    end
-    j = 1
-    if (!my_params[:search_field_row].nil? and my_params[:search_field] == 'advanced')
+    # Delete advanced search params
+    my_params.delete(:q_row)
+    my_params.delete(:search_field_row)
+    my_params.delete(:op_row)
+    my_params.delete(:boolean_row)
+    my_params.delete(:show_query)
 
-     sfr = my_params[:search_field_row][0]
-#     if my_params[:op_row][0] == "begins_with"
-#       sfr = sfr << "_starts"
-#     end
-      new_q_parts[0] = sfr  + "=" + my_params[:q_row][0]
-      for i in 1..my_params[:q_row].count - 1
-        sfr = my_params[:search_field_row][i] #<< "=" << my_params[:q_row][i]
-#        if my_params[:search_field_row][i] == "begins_with"
-#          sfr = sfr << "_starts"
-#
-        n = i - 1
-       # n = n.to_s
-        if !my_params[:boolean_row].nil?
-          if !my_params[:boolean_row][n].nil?
-            new_q_parts[j] = "op[]=" << my_params[:boolean_row][n]
-            new_q_parts[j+1] =  sfr + "=" + my_params[:q_row][i]
-          end
-        end
-        j = j + 2
-      end
-#        q_parts = q_string.split('&')
-    elsif !my_params[:q].nil? and !my_params[:q].blank? and !my_params[:search_field].nil?
-     new_q_parts[0] = "q=" << CGI.escape(my_params[:q])
-     new_q_parts[1] = "search_field=" << my_params[:search_field]
-    end
-    if (new_q_parts.count == 3 )
-       andorcount = 0
-     #  params.delete("advanced_query")
-       0.step(2, 2) do |x|
-         label = ""
-         parts = new_q_parts[x].split('=')
-         if x == 0
-           hold = new_q_parts[2].split('=')
-         else
-           hold = new_q_parts[0].split('=')
-         end
-           if parts[1].nil?
-             parts[1] = ""
-           end
-           querybuttontext = parts[1]
-           if querybuttontext.include?('%26')
-             querybuttontext = querybuttontext.gsub!('%26','&')
-           end
-         if x%2 == 0
-           if x - 1 > 0
-             opval = new_q_parts[x - 1].split('=')
-             label = opval[1] << " "
-             label << search_field_def_for_key(parts[0])[:label]
-           else
-             label = search_field_def_for_key(parts[0])[:label]
-           end
-           if hold[1].nil?
-             hold[1] = ""
-           end
-           if hold[1].include?('&')
-             hold[1] = hold[1].gsub!('&','%26')
-           end
-
-           if my_params[:op_row][andorcount] == "OR"
-             lastq = qtoken(hold[1])
-             if lastq.size > 1
-             #  hold[1] = lastq.product([' OR ']).flatten(1)[0...-1].join()
-             end
-           end
-           boolcount = andorcount + 1
-           boolcount = boolcount.to_s
-           removeString = "catalog?&q_row[]=" + CGI.escape(hold[1]) + "&boolean_row[" + boolcount + "]=AND" + "&op_row[]=" + my_params[:op_row][andorcount] + "&search_field_row[]=" + hold[0] + "&search_field=advanced&" + facetparams + "action=index&commit=Search"
-           content << render_constraint_element(label, querybuttontext, :remove => removeString)
-         else
-          content << " " << querybuttontext << " "
-         end
-         #content #<< "".html_safe
-       end
-      unless !my_params[:q].nil?
-         content << render_simple_constraints_filters(params)
-      else
-         content << render_advanced_constraints_filters(params)
-      end
-      return content.html_safe
-    else
-     if (new_q_parts.count <= 2)
-#            parts = q_parts[0].split('=')
-         if !my_params[:q].nil? and !my_params[:q].blank? and !my_params[:search_field].nil?
-          remove_string = my_params["q"]
-          label = search_field_def_for_key(my_params[:search_field])[:label]
-
-          if(params[:f].nil?)
-            removeString = "?"
-          else
-            removeString = "?" + facetparams
-          end
-          querybuttontext = my_params["q"]
-          if querybuttontext.include?('%26')
-            querybuttontext = querybuttontext.gsub!('%26','&')
-          end
-          if !test.nil?
-            facetparams = test
-          end
-             if querybuttontext.include?('%26')
-               querybuttontext = querybuttontext.gsub!('%26','&')
-             end
-          content << render_constraint_element(
-             label, querybuttontext,
-             :remove => removeString
-          )
-          end
-          if !my_params[:q].nil?
-            content << render_simple_constraints_filters(my_params)
-          else
-            content << render_constraints_filters(my_params)
-          end
-          return content.html_safe
-     else
-        temp_boolean_rows = my_params[:boolean_row]
-        0.step(my_params[:q_row].count - 1, 1) do |x|
-          label = ""
-          opval = ""
-          remove_indexes = []
-          icount = 0
-          temp_search_field_row = []
-          temp_q_row = []
-          temp_op_row = []
-          temp_boolean_row = []
-          deleted = 0
-          0.step(my_params[:q_row].count - 1, 1) do |y|
-             if y != x
-                 temp_q_row << my_params[:q_row][y]
-                 temp_op_row << my_params[:op_row][y]
-                 temp_search_field_row << my_params[:search_field_row][y]
-              end
-
-              end
-   #           if x == 0
-   #             2.step(temp_boolean_rows[:boolean_row].count, 1) do |br|
-   #               ss = br.to_s
-   #               temp_boolean_row << temp_boolean_rows[:boolean_row][ss.to_sym]
-   #             end
-   #           else
-   #             1.step(temp_boolean_rows[:boolean_row].count, 1) do |br|
-   #               if x != br
-   #                ss = br.to_s
-   #                temp_boolean_row << temp_boolean_rows[:boolean_row][ss.to_sym]
-   #               end
-   #             end
-   #           end
-
-               if x >= 0 and x <= temp_boolean_rows.count
-                   opval = temp_boolean_rows[x]
-                   label << search_field_def_for_key(my_params[:search_field_row][x])[:label]
-               else
-                   label = search_field_def_for_key(my_params[:search_field_row][x])[:label]
-               end
-
-               autoparam = ""
-
-
-               autoparam = ""
-               for qp in 0..temp_q_row.length - 1
-
-                  autoparam << "q_row[]=" << CGI.escape(temp_q_row[qp]) << "&op_row[]=" << temp_op_row[qp] << "&search_field_row[]=" << temp_search_field_row[qp]
-                  if qp < temp_q_row.length - 1
-                    autoparam << "&boolean_row[#{qp + 1}]=" << temp_boolean_rows[qp] << "&"
-                  end
-
-
-
-               end
-               querybuttontext = my_params[:q_row][x] #parts[1]
-               if querybuttontext.include?('%26')
-                 querybuttontext = querybuttontext.gsub!('%26','&')
-               end
-               removeString = "catalog?utf8=%E2%9C%93&" + autoparam + "&" + facetparams + "search_field=advanced&action=index&commit=Search&advanced_query=yes"
-               if x > 0
-                 s = x.to_s
-                 label = temp_boolean_rows[x - 1].to_s + " " + label
-               end
-               content << render_constraint_element(
-                 label, querybuttontext,
-#                 :remove => "catalog?utf8=%E2%9C%93&" + autoparam + "&" + facetparams + "&action=index&commit=Search&advanced_query=yes"
-                 :remove => removeString #"catalog?utf8=%E2%9C%93&" + autoparam + "&" + facetparams + "&action=index&commit=Search&advanced_query=yes"
-                 )
-
-       end
-
-       if !my_params[:q].nil?
-         content << render_simple_constraints_filters(my_params)
-       else
-         content << render_advanced_constraints_filters(my_params)
-       end
-       return content.html_safe
-     end
-
-  end
- end
-end
-
-def render_simple_constraints_filters(my_params = params)
-  return_content = ""
-  if(my_params[:f].present?)
-    my_params[:f].each do |key, value|
-      removeString = make_remove_string(my_params,key)
-      label =facet_field_labels[key]
-      if value[0].include?('%26')
-        value[0].gsub!('%26','&')
-      end
-      return_content << render_constraint_element(label,
-        value.join(" AND "),
-        :remove => "?" + removeString
-        )
-    end
-  end
-  return return_content.html_safe
-end
-
-
-def render_advanced_constraints_filters(params)
-  # Create deep copy of params to not alter original search params hash
-  my_params = params.present? ? params.deep_dup : {}
-
-  return_content = ''
-  if my_params[:f].present?
-    my_params[:f].each do |key, value|
-      label = facet_field_labels[key]
-      value[0].gsub!('%26', '&')
-      remove_string = make_remove_string(my_params, key)
-
-      return_content << render_constraint_element(label,
-                                                  value.join(' AND '),
-                                                  :remove => '?' + remove_string)
-    end
+    return render_constraints(my_params)
   end
 
-  return return_content.html_safe
+  content = ''
+  my_params[:q_row].each_with_index do |query, i|
+    # Constraint label
+    label = search_field_def_for_key(my_params[:search_field_row][i])[:label]
+    # Constraint label with boolean
+    boolean_index = [i - 1, 0].max
+    bool_arr = my_params[:boolean_row].values
+    label = "#{bool_arr[boolean_index]} #{label}" if i > 0
+
+    # Get search path minus the current row
+    removed_params = my_params.deep_dup
+    removed_params[:q_row].delete_at(i)
+    removed_params[:search_field_row].delete_at(i)
+    removed_params[:op_row].delete_at(i)
+    # Reset number keys in boolean_row
+    bool_arr.delete_at(boolean_index)
+    removed_params[:boolean_row] = Hash[("1"..bool_arr.size.to_s).zip bool_arr]
+    remove_path = search_catalog_path(removed_params)
+
+    content << render_constraint_element(label, query, :remove => remove_path)
+  end
+
+  content << render_constraints_filters(params)
+  content.html_safe
 end
 
 def render_edit_advanced_constraints_filters(my_params = params)
@@ -573,116 +246,6 @@ def render_edit_advanced_constraints_filters(my_params = params)
   end
  # return removeString.html_safe
   return return_content.html_safe
-end
-
-def make_remove_string(my_params, facet_key)
-  removeString = ""
-  fkey = facet_key
-  advanced_query = my_params["advanced_query"]
-  advanced_search = my_params["advanced_search"]
-  show_query_string = ""
-  if !advanced_search.nil?
-    advanced_search = "true"
-  else
-    advanced_search = "false"
-  end
-  boolean_row = my_params["boolean_row"]
-  boolean_row_string = ""
-  if !boolean_row.nil? #and boolean_row.count >= 1
-   boolean_row.each do |key, value|
-     if !key.nil? and !value.nil?
-     boolean_row_string << "boolean_row[" + key + "]=" + value + "&"
-     else
-      boolean_row_string << "boolean_row[1]=" + my_params["boolean_row"][0] + "&"
-     end
-   end
-
-  else
-    boolean_row_string = "boolean_row[1]=" #+ my_params["boolean_row"]
-  end
-  if !boolean_row_string.blank?
-    boolean_row_string << "&"
-  end
-  facets = my_params[:f]
-  facets_string = ""
-  if !facets.nil?
-    facets.each do |key, value|
-      if key != fkey
-        for i in 0..value.count - 1 do
-          if value[i].include? 'Kroch Library Rare'
-            value[i] = 'Kroch Library Rare %26 Manuscripts'
-          end
-          facets_string << "f[" << key << "][]=" << value[i] << "&"
-        end
-      end
-    end
-  end
-  if !facets_string.blank?
-    facets_string << "&"
-  end
-  op = my_params["op"]
-  op_string = ""
-  if !op.nil?
-    for i in 0..op.count - 1 do
-      op_string << "op[]=" << op[i] << "&"
-    end
-  end
-  op_row = my_params["op_row"]
-  op_row_string = ""
-  if !op_row.nil?
-    for i in 0..op_row.count - 1 do
-      op_row_string << "op_row[]=" << op_row[i] << "&"
-    end
-  end
-  q = my_params[:q]
-  q_string = ""
-  if !q.nil?
-    if q.include?('=')
-     q = q.gsub!('=','%3D')
-    end
-    if q.include?('&')
-     q = q.gsub!('&', '%26')
-    end
-    q_string = "q=" << CGI.escape(q) << "&"
-  else
-    q = ""
-  end
-  q_row = my_params["q_row"]
-  q_row_string = ""
-  if !q_row.nil?
-    for i in 0..q_row.count - 1
-      q_row_string << "q_row[]=" << CGI.escape(q_row[i]) << "&"
-    end
-  end
-  search_field = my_params["search_field"]
-  search_field_string = ""
-  if !search_field.nil?
-    search_field_string = "search_field=" << search_field << "&"
-  end
-  search_field_row = my_params["search_field_row"]
-  search_field_row_string = ""
-  if !search_field_row.nil?
-    for i in 0..search_field_row.count - 1
-      search_field_row_string << "search_field_row[]=" << search_field_row[i] << "&"
-    end
-  end
-  if ((q_row.nil? || q_row.count < 2) && !q.nil?)
-    if CGI.escape(q) == ''
-      if facets_string != ''
-        removeString = facets_string + "action=index&commit=Search"
-      end
-    else
-       removeString = "q=" + CGI.escape(q) + "&" +search_field_string + "action=index&commit=Search"
-    end
-  else
-    if advanced_query.nil?
-      advanced_query = "yes"
-    end
-    removeString << "advanced_query=" + advanced_query + "&advanced_search=" + advanced_search + "&" + boolean_row_string +
-                  facets_string + op_string + op_row_string + q_string.html_safe +
-                  q_row_string + search_field_string + search_field_row_string
-  end
-  return removeString
 end
 
 def makeEditRemoveString(my_params, facet_key)

--- a/blacklight-cornell/app/helpers/display_helper.rb
+++ b/blacklight-cornell/app/helpers/display_helper.rb
@@ -1286,10 +1286,17 @@ end
     end
     ## Sends 'correct' q param to link_link_to_previous_search
     params[:q] = showText
-    ## Uses overridden render_search_to_s_q(params) function below originally from app/helper/blacklight/search_history_constraints_helper_behavior.rb
-    showText = link_to_previous_search(params)
+    # Uses newer version of #link_to_previous_search from blacklight to include f_inclusive filters
+    showText = link_to_previous_search_override(params)
 
     return showText
+  end
+
+  # Can remove and replace with #link_to_previous_search in blacklight >= v8.0.0: https://github.com/projectblacklight/blacklight/pull/2626
+  # Use in e.g. the search history display, where we want something more like text instead of the normal constraints
+  def link_to_previous_search_override(params)
+    search_state = controller.search_state_class.new(params, blacklight_config, self)
+    link_to(render(Blacklight::ConstraintsComponent.for_search_history(search_state: search_state)), search_action_path(params))
   end
 
   def parseHistoryQueryString(params)

--- a/blacklight-cornell/app/presenters/blacklight/facet_checkbox_item_presenter.rb
+++ b/blacklight-cornell/app/presenters/blacklight/facet_checkbox_item_presenter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Can remove this in blacklight >= v8.4.0: https://github.com/projectblacklight/blacklight/pull/3278/files
+module Blacklight
+  class FacetCheckboxItemPresenter < Blacklight::FacetItemPresenter
+    # Check if the query parameters have any inclusive facets with the given value
+    # @return [Boolean]
+    def selected?
+      search_state.filter(facet_config).values(except: [:filters, :missing]).flatten.include?(value)
+    end
+  end
+end

--- a/blacklight-cornell/app/views/advanced_search/_facets.html.erb
+++ b/blacklight-cornell/app/views/advanced_search/_facets.html.erb
@@ -1,0 +1,5 @@
+<% @facets.each do |_k, facet| %>
+  <% presenter = Blacklight::FacetFieldPresenter.new(facet[:field_config], facet[:display_facet], self) %>
+  <%# TODO: render Blacklight::FacetFieldCheckboxesComponent after upgrading to blacklight >= v8.4.0 %>
+  <%= render AdvancedFacetFieldCheckboxesComponent.new(facet_field: presenter) %>
+<% end %>

--- a/blacklight-cornell/app/views/advanced_search/_form.html.erb
+++ b/blacklight-cornell/app/views/advanced_search/_form.html.erb
@@ -1,6 +1,7 @@
 <div class='card card-body card-well'>
   <%= form_with url: search_catalog_path, class: 'advanced', method: :get do |form| %>
     <div class='query_zone'>
+      <h3>Enter search terms</h3>
       <%# Display at least 2 search rows %>
       <% [form_row_values.count, 2].max().times do |i| %>
         <% form_values_for_row = form_row_values[i] || {} %>
@@ -12,11 +13,14 @@
       <div class='add-row'>
         <a href='#' id='add-row'><i class='fa fa-plus-circle'></i> Add a row</a>
       </div>
+      <h3>Limit your results</h3>
       <% if params['action'] == 'edit' %>
         <div class='advanced-facets'>
           <%= render_edit_advanced_constraints_filters(params) %>
       	</div>
       <% end %>
+      <%= render 'facets', form: form %>
+      <h3>Sort results</h3>
       <div class='form-group'>
         <%= form.label :sort, t('blacklight.search.form.sort'), class: 'sort-results' %>
         <%= form.select :sort, advanced_search_sort_opts, {}, { class: 'form-control adv-search-control' } %>

--- a/blacklight-cornell/app/views/catalog/_constraints.html.erb
+++ b/blacklight-cornell/app/views/catalog/_constraints.html.erb
@@ -19,7 +19,7 @@
     <% end %>
   <% if params[:q_row].present? && params[:action] != 'edit'%>
   <div class="modify-search-link">
-        <%= link_to 'Modify advanced search', url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f]), :class=>"btn btn-search" %>
+        <%= link_to 'Modify advanced search', url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive]), :class=>"btn btn-search" %>
       </div>
     <% end %>
   </div>

--- a/blacklight-cornell/app/views/catalog/_constraints.html.erb
+++ b/blacklight-cornell/app/views/catalog/_constraints.html.erb
@@ -1,12 +1,10 @@
-<%#= params[:q].inspect%>
 <%params[:y] = params[:q] %>
 <% params[:q] = params[:show_query] if  params[:show_query]%>
 <% if params[:action] != 'edit' && query_has_constraints? || params[:range].present? %>
   <div class="selected-facets">
   	<%=link_to t('blacklight.search.start_over'), url_for(:action=>'index'), :id=>"startOverLink", :class=>"btn btn-light" %>
     <span class="constraints-label hidden"><% t('blacklight.search.filters.title') %></span>
-    <%#= params.inspect %>
-    <%if params[:q_row].nil? && params[:f].nil? %>
+    <% if params[:q_row].nil? && params[:f].nil? && params[:f_inclusive].nil? %>
         <% if params[:search_field] && params[:search_field] != 'advanced'%>
     	     <%= render_constraints_cts(params) %>
         <% end %>
@@ -17,7 +15,7 @@
     <%= render_constraints(params) %>
 
     <% end %>
-  <% if params[:q_row].present? && params[:action] != 'edit'%>
+  <% if (params[:q_row].present? || params[:f_inclusive].present?) && params[:action] != 'edit'%>
   <div class="modify-search-link">
         <%= link_to 'Modify advanced search', url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive]), :class=>"btn btn-search" %>
       </div>

--- a/blacklight-cornell/features/catalog_search/advanced_search.feature
+++ b/blacklight-cornell/features/catalog_search/advanced_search.feature
@@ -495,9 +495,7 @@ Feature: Search
     And I select 'Title' from the 'search_field_row1' drop-down
     And I press 'advanced_search'
     Then I should get results
-    Then it should have link "Title: beef" with value 'catalog?&q_row[]=100%25&boolean_row[1]=AND&op_row[]=AND&search_field_row[]=title&search_field=advanced&action=index&commit=Search'
-    #Then it should have link "Title: beef" with value 'catalog?&q=100%25&search_field=title&action=index&commit=Search'
-    #Then it should have link "Title: beef" with value 'catalog?&amp;q=100%&amp;search_field=title&amp;action=index&amp;commit=Search'
+    Then it should have link "Title: beef" with value '/catalog?action=index&advanced_query=yes&commit=Search&controller=catalog&op_row%5B%5D=AND&q=title+%3D+100%25&q_row%5B%5D=100%25&search_field=advanced&search_field_row%5B%5D=title&show_query=title+%3D+100%25&sort=score+desc%2C+pub_date_sort+desc%2C+title_sort+asc&utf8=%E2%9C%93'
     Then I remove facet constraint "beef"
 
 

--- a/blacklight-cornell/features/catalog_search/advanced_search.feature
+++ b/blacklight-cornell/features/catalog_search/advanced_search.feature
@@ -758,3 +758,13 @@ Scenario: Empty searches produce empty solr queries in advanced and simple searc
     And I fill in "q_row0" with ''
     And I press 'advanced_search'
     Then the solr query should be ''
+
+@javascript
+Scenario: I can filter advanced searches by multiple languages
+  When I literally go to advanced
+  And I fill in "q_row0" with 'Canada'
+  And I press 'Language'
+  And I should select checkbox "f_inclusive_language_facet_6"
+  And I should select checkbox "f_inclusive_language_facet_7"
+  And I press 'advanced_search'
+  Then I should get 4 results

--- a/blacklight-cornell/spec/controllers/advanced_search_controller_spec.rb
+++ b/blacklight-cornell/spec/controllers/advanced_search_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe AdvancedSearchController do
+  describe 'GET index' do
+    it 'assigns @facets and renders the index template' do
+      get :index
+      expect(assigns(:facets)['language_facet']).to be_present
+      expect(response).to render_template('index')
+    end
+  end
+
+  describe 'GET edit' do
+    it 'assigns @facets and renders the edit template' do
+      get :edit, params: { f: { language_facet: ['English'] }, f_inclusive: { language_facet: ['English', 'French'] } }
+      expect(assigns(:facets)['language_facet']).to be_present
+      expect(response).to render_template('edit')
+    end
+  end
+end

--- a/blacklight-cornell/spec/helpers/cornell_params_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/cornell_params_helper_spec.rb
@@ -1,0 +1,220 @@
+require 'rails_helper'
+
+describe BrowseHelper do
+  let(:blacklight_config) { CatalogController.blacklight_config }
+
+  describe '#remove_blank_rows' do
+    context 'single row query' do
+      context 'query is not blank' do
+        it 'removes last blank row' do
+          params = helper.remove_blank_rows({ q_row: ['test', ''],
+                                              op_row: ['AND', 'AND'],
+                                              search_field_row: ['all_fields', 'all_fields'],
+                                              boolean_row: { '1' => 'AND' } })
+          expect(params).to eq({ q_row: ['test'], op_row: ['AND'], search_field_row: ['all_fields'], boolean_row: {} })
+        end
+      end
+
+      context 'query is blank' do
+        it 'removes blank rows' do
+          params = helper.remove_blank_rows({ q_row: ['', ''],
+                                              op_row: ['AND', 'AND'],
+                                              search_field_row: ['all_fields', 'all_fields'],
+                                              boolean_row: { '1' => 'AND' } })
+          expect(params).to eq({ q_row: [], op_row: [], search_field_row: [], boolean_row: {} })
+        end
+      end
+    end
+
+    context 'multiple row query' do
+      context 'query is not blank' do
+        it 'returns expected params' do
+          params = helper.remove_blank_rows({ q_row: ['pickles', 'cheese', 'toast'],
+                                              op_row: ['AND', 'AND', 'begins_with'],
+                                              search_field_row: ['title', 'all_fields', 'notes'],
+                                              boolean_row: { '1' => 'OR', '2' => 'AND' } })
+          expect(params).to eq({ q_row: ['pickles', 'cheese', 'toast'],
+                                op_row: ['AND', 'AND', 'begins_with'],
+                                search_field_row: ['title', 'all_fields', 'notes'],
+                                boolean_row: { '1' => 'OR', '2' => 'AND' } })
+        end
+      end
+      
+      context 'middle query is blank' do
+        it 'removes blank row' do
+          params = helper.remove_blank_rows({ q_row: ['pickles', '', 'toast'],
+                                              op_row: ['AND', 'AND', 'begins_with'],
+                                              search_field_row: ['title', 'all_fields', 'notes'],
+                                              boolean_row: { '1' => 'OR', '2' => 'AND' } })
+          expect(params).to eq({ q_row: ['pickles', 'toast'],
+                                op_row: ['AND', 'begins_with'],
+                                search_field_row: ['title', 'notes'],
+                                boolean_row: { '1' => 'AND' } })
+        end
+
+        it 'removes blank rows' do
+          params = helper.remove_blank_rows({ q_row: ['pickles', '', '', 'sandwich'],
+                                              op_row: ['AND', 'AND', 'begins_with', 'OR'],
+                                              search_field_row: ['title', 'all_fields', 'notes', 'subject'],
+                                              boolean_row: { '1' => 'OR', '2' => 'AND', '3' => 'NOT' } })
+          expect(params).to eq({ q_row: ['pickles', 'sandwich'],
+                                op_row: ['AND', 'OR'],
+                                search_field_row: ['title', 'subject'],
+                                boolean_row: { '1'  => 'NOT' } })
+        end
+      end
+
+      context 'first query is blank' do
+        it 'removes blank rows' do
+          params = helper.remove_blank_rows({ q_row: ['', 'cheese', 'toast'],
+                                              op_row: ['AND', 'AND', 'begins_with'],
+                                              search_field_row: ['title', 'all_fields', 'notes'],
+                                              boolean_row: { '1' => 'OR', '2' => 'AND' } })
+          expect(params).to eq({ q_row: ['cheese', 'toast'],
+                                op_row: ['AND', 'begins_with'],
+                                search_field_row: ['all_fields', 'notes'],
+                                boolean_row: { '1'  => 'AND' } })
+        end
+      end
+    end
+
+    context "row counts don't match" do
+      context 'q_row count is less than boolean, op, or search_field row counts' do
+        it 'removes extra boolean, op, or search_field rows' do
+          params = helper.remove_blank_rows({ q_row: ['pickles', 'cheese'],
+                                              op_row: ['AND', 'AND', 'begins_with'],
+                                              search_field_row: ['title', 'all_fields', 'notes'],
+                                              boolean_row: { '1' => 'OR', '2' => 'AND' } })
+          expect(params).to eq({ q_row: ['pickles', 'cheese'],
+          op_row: ['AND', 'AND'],
+          search_field_row: ['title', 'all_fields'],
+          boolean_row: { '1'  => 'OR' } })
+        end
+      end
+
+      context 'q_row_count is more than boolean, op, or search_field row counts' do
+        it 'returns params with default booleans, ops, or search_fields when missing' do
+          params = helper.remove_blank_rows({ q_row: ['pickles', 'cheese', 'toast'],
+                                              op_row: ['AND', 'begins_with'],
+                                              search_field_row: ['title', 'notes'],
+                                              boolean_row: { '1' => 'OR' } })
+          expect(params).to eq({ q_row: ['pickles', 'cheese', 'toast'],
+          op_row: ['AND', 'begins_with', 'AND'],
+          search_field_row: ['title', 'notes', 'all_fields'],
+          boolean_row: { '1'  => 'OR', '2'  => 'AND' } })
+        end
+      end
+
+      context 'boolean, op, or search_field keys are completely missing' do
+        it 'returns params with default booleans, ops, or search_fields' do
+          params = helper.remove_blank_rows({ q_row: ['pickles', 'cheese', 'toast'] })
+          expect(params).to eq({ q_row: ['pickles', 'cheese', 'toast'],
+          op_row: ['AND', 'AND', 'AND'],
+          search_field_row: ['all_fields', 'all_fields', 'all_fields'],
+          boolean_row: { '1'  => 'AND', '2'  => 'AND' } })
+        end
+      end
+    end
+  end
+
+  describe '#render_advanced_constraints_query' do
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:blacklight_config) { blacklight_config }
+        allow(controller).to receive(:search_state_class).and_return(Blacklight::SearchState)
+        allow(helper).to receive(:search_state).and_return(CatalogController.search_state_class.new(params, blacklight_config, helper))
+        allow(helper).to receive(:search_action_path) { |*args| search_catalog_url *args }
+      end
+    end
+
+    context 'single query row' do
+      before do
+        without_partial_double_verification do
+          allow(helper).to receive(:default_search_field).and_return(blacklight_config.default_search_field)
+        end
+      end
+
+      it 'returns expected constraint links' do
+        params = { q_row: ['pickles'],
+                  op_row: ['AND'],
+                  search_field_row: ['title'],
+                  boolean_row: {} }
+        constraints_html = helper.render_advanced_constraints_query(params)
+        constraints_doc = Nokogiri::HTML(constraints_html)
+        link_nodes = constraints_doc.css('a')
+        expect(link_nodes.count).to eq(1)
+
+        # Query constraint
+        expect(link_nodes[0].content.strip.gsub(/\s+/, ' ')).to eq('Title: pickles')
+        # For some reason search_field remains in the params
+        expect(link_nodes[0]['href']).to eq(search_catalog_url({ search_field: 'title' }))
+      end
+    end
+
+    context 'multiple query rows' do
+      before do
+        without_partial_double_verification do
+          allow(helper).to receive(:blacklight_config) { blacklight_config }
+          allow(helper).to receive(:search_field_def_for_key).with('title') { blacklight_config.search_fields['title'] }
+          allow(helper).to receive(:search_field_def_for_key).with('all_fields') { blacklight_config.search_fields['all_fields'] }
+          allow(helper).to receive(:search_field_def_for_key).with('notes') { blacklight_config.search_fields['notes'] }
+        end
+      end
+
+      it 'returns expected constraint links' do
+        params = { q_row: ['pickles', 'cheese', 'toast'],
+                  op_row: ['AND', 'AND', 'begins_with'],
+                  search_field_row: ['title', 'all_fields', 'notes'],
+                  boolean_row: { '1' => 'OR', '2' => 'AND' },
+                  f: { 'format' => ['Book'], 'language_facet' => ['English', 'French'] },
+                  f_inclusive: { 'language_facet' => ['English', 'French'] } }
+        constraints_html = helper.render_advanced_constraints_query(params)
+        constraints_doc = Nokogiri::HTML(constraints_html)
+        link_nodes = constraints_doc.css('a')
+        expect(link_nodes.count).to eq(7)
+
+        # First query constraint
+        expect(link_nodes[0].content.strip.gsub(/\s+/, ' ')).to eq('Title: pickles')
+        removed_query_params = params.deep_dup
+        removed_query_params[:q_row].delete_at(0)
+        removed_query_params[:op_row].delete_at(0)
+        removed_query_params[:search_field_row].delete_at(0)
+        removed_query_params[:boolean_row] = { '1' => 'AND' }
+        expect(link_nodes[0]['href']).to eq(search_catalog_path(removed_query_params))
+
+        # Second query constraint
+        expect(link_nodes[1].content.strip.gsub(/\s+/, ' ')).to eq('OR All Fields: cheese')
+        removed_query_params = params.deep_dup
+        removed_query_params[:q_row].delete_at(1)
+        removed_query_params[:op_row].delete_at(1)
+        removed_query_params[:search_field_row].delete_at(1)
+        removed_query_params[:boolean_row] = { '1' => 'AND' }
+        expect(link_nodes[1]['href']).to eq(search_catalog_path(removed_query_params))
+
+        # Third query constraint
+        expect(link_nodes[2].content.strip.gsub(/\s+/, ' ')).to eq('AND Notes: toast')
+        removed_query_params = params.deep_dup
+        removed_query_params[:q_row].delete_at(2)
+        removed_query_params[:op_row].delete_at(2)
+        removed_query_params[:search_field_row].delete_at(2)
+        removed_query_params[:boolean_row] = { '1' => 'OR' }
+        expect(link_nodes[2]['href']).to eq(search_catalog_path(removed_query_params))
+
+        # Filter constraints from search results facets
+        expect(link_nodes[3].content.strip.gsub(/\s+/, ' ')).to eq('Format: Book')
+        removed_f_format_param = params[:f].except('format')
+        expect(link_nodes[3]['href']).to eq(search_catalog_url(params.merge({ f: removed_f_format_param })))
+        expect(link_nodes[4].content.strip.gsub(/\s+/, ' ')).to eq('Language: English')
+        removed_f_english_param = { 'format' => ['Book'], 'language_facet' => ['French'] }
+        expect(link_nodes[4]['href']).to eq(search_catalog_url(params.merge({ f: removed_f_english_param })))
+        expect(link_nodes[5].content.strip.gsub(/\s+/, ' ')).to eq('Language: French')
+        removed_f_french_param = { 'format' => ['Book'], 'language_facet' => ['English'] }
+        expect(link_nodes[5]['href']).to eq(search_catalog_url(params.merge({ f: removed_f_french_param })))
+
+        # Filter constraint from advanced search form
+        expect(link_nodes[6].content.strip.gsub(/\s+/, ' ')).to eq('Language: English OR French')
+        expect(link_nodes[6]['href']).to eq(search_catalog_url(params.except(:f_inclusive)))
+      end
+    end
+  end
+end

--- a/blacklight-cornell/spec/helpers/display_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/display_helper_spec.rb
@@ -1,79 +1,119 @@
 require 'rails_helper'
 
 RSpec.describe DisplayHelper, type: :helper do
-  before do
-    without_partial_double_verification do
-      allow(helper).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
-      allow(helper).to receive(:process_online_title).and_return('Processed Title')
+  describe '#render_display_link' do
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
+        allow(helper).to receive(:process_online_title).and_return('Processed Title')
+      end
+    end
+
+    context 'when links are provided in args[:value]' do
+      let(:args) { { field: 'url_findingaid_display', value: ['http://example.com|Example'] } }
+
+      it 'renders the display link' do
+        result = helper.render_display_link(args)
+        expect(result.first).to include('Processed Title')
+        expect(result.first).to include('http://example.com')
+      end
+    end
+
+    context 'when links are fetched from args[:document]' do
+      let(:document) { { 'url_findingaid_display' => ['http://example.com|Example'] } }
+      let(:args) { { field: 'url_findingaid_display', document: document } }
+
+      it 'renders the display link' do
+        result = helper.render_display_link(args)
+        expect(result.first).to include('Processed Title')
+        expect(result.first).to include('http://example.com')
+      end
+    end
+
+    context 'when render_format is raw' do
+      let(:args) { { field: 'url_findingaid_display', value: ['http://example.com|Example'], format: 'raw' } }
+
+      it 'returns the raw value' do
+        result = helper.render_display_link(args)
+        expect(result).to be_an(Array)
+        expect(result.first).to include('Processed Title')
+        expect(result.first).to include('http://example.com')
+      end
+    end
+
+    context 'when field is url_findingaid_display' do
+      let(:args) { { field: 'url_findingaid_display', value: ['http://example.com|Example', 'http://example2.com|Example2'] } }
+
+      it 'returns all the values' do
+        result = helper.render_display_link(args)
+        expect(result).to be_an(Array)
+        expect(result.length).to eq(2)
+        expect(result.first).to include('Processed Title')
+        expect(result.first).to include('http://example.com')
+        expect(result.last).to include('http://example2.com')
+      end
+    end
+
+    context 'when field is url_bookplate_display' do
+      let(:args) { { field: 'url_bookplate_display', value: ['http://example.com|Example', 'http://example2.com|Example2'] } }
+
+      it 'returns unique values joined by commas' do
+        result = helper.render_display_link(args)
+        expect(result).to include('Processed Title')
+        expect(result).to include('http://example.com')
+        expect(result).to include('http://example2.com')
+        expect(result).to include(',')
+      end
+    end
+
+    context 'when field is url_other_display' do
+      let(:args) { { field: 'url_other_display', value: ['http://example.com|Example', 'http://example2.com|Example2'] } }
+
+      it 'returns values joined by <br/>' do
+        result = helper.render_display_link(args)
+        expect(result).to include('Processed Title')
+        expect(result).to include('http://example.com')
+        expect(result).to include('http://example2.com')
+        expect(result).to include('<br/>')
+      end
     end
   end
 
-  context 'when links are provided in args[:value]' do
-    let(:args) { { field: 'url_findingaid_display', value: ['http://example.com|Example'] } }
+  describe '#parseHistoryShowString' do
+    let(:blacklight_config) { CatalogController.blacklight_config }
+    let(:all_fields_config) { blacklight_config.default_search_field}
 
-    it 'renders the display link' do
-      result = helper.render_display_link(args)
-      expect(result.first).to include('Processed Title')
-      expect(result.first).to include('http://example.com')
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
+        allow(helper).to receive(:search_field_def_for_key).and_return(all_fields_config)
+        allow(helper).to receive(:default_search_field).and_return(all_fields_config)
+        allow(helper).to receive(:search_action_path) { |*args| search_catalog_url *args }
+        allow(controller).to receive(:search_state_class).and_return(Blacklight::SearchState)
+        allow(helper).to receive(:search_state).and_return(CatalogController.search_state_class.new(params, blacklight_config, helper))
+      end
     end
-  end
 
-  context 'when links are fetched from args[:document]' do
-    let(:document) { { 'url_findingaid_display' => ['http://example.com|Example'] } }
-    let(:args) { { field: 'url_findingaid_display', document: document } }
-
-    it 'renders the display link' do
-      result = helper.render_display_link(args)
-      expect(result.first).to include('Processed Title')
-      expect(result.first).to include('http://example.com')
-    end
-  end
-
-  context 'when render_format is raw' do
-    let(:args) { { field: 'url_findingaid_display', value: ['http://example.com|Example'], format: 'raw' } }
-
-    it 'returns the raw value' do
-      result = helper.render_display_link(args)
-      expect(result).to be_an(Array)
-      expect(result.first).to include('Processed Title')
-      expect(result.first).to include('http://example.com')
-    end
-  end
-
-  context 'when field is url_findingaid_display' do
-    let(:args) { { field: 'url_findingaid_display', value: ['http://example.com|Example', 'http://example2.com|Example2'] } }
-
-    it 'returns all the values' do
-      result = helper.render_display_link(args)
-      expect(result).to be_an(Array)
-      expect(result.length).to eq(2)
-      expect(result.first).to include('Processed Title')
-      expect(result.first).to include('http://example.com')
-      expect(result.last).to include('http://example2.com')
-    end
-  end
-
-  context 'when field is url_bookplate_display' do
-    let(:args) { { field: 'url_bookplate_display', value: ['http://example.com|Example', 'http://example2.com|Example2'] } }
-
-    it 'returns unique values joined by commas' do
-      result = helper.render_display_link(args)
-      expect(result).to include('Processed Title')
-      expect(result).to include('http://example.com')
-      expect(result).to include('http://example2.com')
-      expect(result).to include(',')
-    end
-  end
-
-  context 'when field is url_other_display' do
-    let(:args) { { field: 'url_other_display', value: ['http://example.com|Example', 'http://example2.com|Example2'] } }
-
-    it 'returns values joined by <br/>' do
-      result = helper.render_display_link(args)
-      expect(result).to include('Processed Title')
-      expect(result).to include('http://example.com')
-      expect(result).to include('http://example2.com')
-      expect(result).to include('<br/>')
+    it 'returns expected html' do
+      params = {
+        advanced_query: 'yes',
+        boolean_row: { '1' => 'AND' },
+        f: { language_facet: 'Cebuano' },
+        f_inclusive: { language_facet: ['English', 'French'] },
+        op_row: ['AND', 'AND'],
+        q_row: ['Canada', ''],
+        search_field: 'advanced',
+        search_field_row: ['all_fields', 'all_fields'],
+        sort: 'score desc, pub_date_sort desc, title_sort asc',
+        controller: 'catalog',
+        action: 'index',
+        only_path: true
+      }
+      link_html = helper.parseHistoryShowString(params)
+      link_sans_html = strip_tags(link_html)
+      expect(link_sans_html).to include('All Fields: Canada')
+      expect(link_sans_html).to include('Language:Cebuano')
+      expect(link_sans_html).to include('Language:English OR French')
     end
   end
 end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-290

This PR creates a new section for facets in the advanced search form. Uses built-in blacklight advanced search facet component, i.e. behaves and looks similar to Language facet in Stanford's SearchWorks advanced search form.
https://searchworks.stanford.edu/advanced
https://searchworks.stanford.edu/?op=must&clause%5B0%5D%5Bfield%5D=search&clause%5B0%5D%5Bquery%5D=&clause%5B1%5D%5Bfield%5D=search_title&clause%5B1%5D%5Bquery%5D=&clause%5B2%5D%5Bfield%5D=search_author&clause%5B2%5D%5Bquery%5D=&clause%5B3%5D%5Bfield%5D=subject_terms&clause%5B3%5D%5Bquery%5D=&clause%5B4%5D%5Bfield%5D=series_search&clause%5B4%5D%5Bquery%5D=&clause%5B5%5D%5Bfield%5D=pub_search&clause%5B5%5D%5Bquery%5D=&clause%5B6%5D%5Bfield%5D=isbn_search&clause%5B6%5D%5Bquery%5D=&range%5Bpub_year_tisim%5D%5Bbegin%5D=&range%5Bpub_year_tisim%5D%5Bend%5D=&f_inclusive%5Blanguage%5D%5B%5D=English&f_inclusive%5Blanguage%5D%5B%5D=French&sort=relevance&commit=Search

Facet is initially collapsed:
![Screenshot 2025-04-22 at 3 19 07 PM](https://github.com/user-attachments/assets/2a9bb1dc-ce18-47c7-a095-673f00843124)

Facet when expanded:
![Screenshot 2025-04-22 at 3 19 18 PM](https://github.com/user-attachments/assets/4257b525-ee51-4bfc-8e95-a233269d2e19)

Constraints in search results when English and French selected in advanced search form:
![Screenshot 2025-04-22 at 3 20 56 PM](https://github.com/user-attachments/assets/0cfde5fb-a12d-4a0c-8834-f3c091400d08)

Facet panel in search results sidebar when English and French selected in advanced search form:
![Screenshot 2025-04-22 at 3 21 05 PM](https://github.com/user-attachments/assets/4ac1ae88-cb32-493b-8068-30c8795c4f52)

Search results filters applied on top of advanced search filters (i.e. advanced search with French and English filter, click "Search", filter further by "Book" from search results, then "Modify advanced search"):
![Screenshot 2025-04-22 at 3 21 52 PM](https://github.com/user-attachments/assets/3f1808b4-ab81-4b33-89ca-3574f280e697)

Search history row when English and French selected in advanced search form and Book facet selected from search results:
![Screenshot 2025-04-22 at 3 23 16 PM](https://github.com/user-attachments/assets/7408ed16-db43-4734-ace8-32de0350862b)