### PR TITLE
DACCESS-428

### DIFF
--- a/blacklight-cornell/app/views/advanced_search/_form.html.erb
+++ b/blacklight-cornell/app/views/advanced_search/_form.html.erb
@@ -14,7 +14,7 @@
         <a href='#' id='add-row'><i class='fa fa-plus-circle'></i> Add a row</a>
       </div>
       <h3>Limit your results</h3>
-      <% if params['action'] == 'edit' %>
+      <% if params[:f].present? %>
         <div class='advanced-facets'>
           <%= render_edit_advanced_constraints_filters(params) %>
       	</div>


### PR DESCRIPTION
Only output advanced constraints div if there are constraints. We currently display this if there aren't constraints in the advanced search edit form:

```
<div class="advanced-facets">     
</div>
```

It adds a wee bit more spacing as well as an empty div. Can we only display the `div` if there are actually constraints?