### PR TITLE
DACCESS-519 - No special handling of booleans in user query

### DIFF
--- a/blacklight-cornell/app/models/search_builder.rb
+++ b/blacklight-cornell/app/models/search_builder.rb
@@ -98,7 +98,7 @@ class SearchBuilder < Blacklight::SearchBuilder
       end
 
       # Build solr q param for simple and bento search
-      solr_parameters[:q] = build_simple_search_query(blacklight_params, blacklight_params[:bento])
+      solr_parameters[:q] = build_simple_search_query(blacklight_params)
     end
   end
 
@@ -153,18 +153,13 @@ class SearchBuilder < Blacklight::SearchBuilder
     params.merge(cleaned_params)
   end
 
-  def build_simple_search_query(params, bento=false)
+  def build_simple_search_query(params)
     return '' if params[:q].blank? || !params[:q].is_a?(String)
 
     query = clean_q(params[:q])
 
-    # Ideally, bento and simple search would use the same logic: https://culibrary.atlassian.net/browse/DACCESS-519
-    if bento && query =~ /AND|OR|NOT/
-      query
-    else
-      search_field = params[:search_field]
-      set_q_with_search_fields(query: query, search_field: search_field)
-    end
+    search_field = params[:search_field]
+    set_q_with_search_fields(query: query, search_field: search_field)
   end
 
   def build_advanced_search_query(params)

--- a/blacklight-cornell/app/models/search_builder.rb
+++ b/blacklight-cornell/app/models/search_builder.rb
@@ -98,7 +98,7 @@ class SearchBuilder < Blacklight::SearchBuilder
       end
 
       # Build solr q param for simple and bento search
-      solr_parameters[:q] = build_simple_search_query(blacklight_params, bento: blacklight_params[:bento])
+      solr_parameters[:q] = build_simple_search_query(blacklight_params, blacklight_params[:bento])
     end
   end
 

--- a/blacklight-cornell/spec/models/search_builder_spec.rb
+++ b/blacklight-cornell/spec/models/search_builder_spec.rb
@@ -1157,22 +1157,6 @@ RSpec.describe SearchBuilder, type: :model do
         })).to eq('(title:"cats" AND title:"dogs") OR title_phrase:"cats dogs"')
       end
     end
-
-    context 'bento search' do
-      it 'returns the cleaned-up query string with search fields and added bools' do
-        expect(search_builder.build_simple_search_query({
-          q: 'cats: dogs', search_field: 'all_fields'
-        }, true)).to eq('("cats\:" AND "dogs") OR phrase:"cats\: dogs"')
-      end
-
-      context 'query includes capitalized booleans' do
-        it 'returns the cleaned-up query string without search fields or added bools' do
-          expect(search_builder.build_simple_search_query({
-          q: 'cats: AND dogs', search_field: 'all_fields'
-        }, true)).to eq('cats\: AND dogs')
-        end
-      end
-    end
   end
 
   describe '#set_query' do


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-519

Example: "cats AND dogs" should return the same # of results per format in simple, advanced, and bento searches.