### PR TITLE
DACCESS-488: increase contrast of search history labels

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_search-results.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_search-results.scss
@@ -169,7 +169,7 @@ body.book_bags-index #documents .document {
 	a:hover { text-decoration: none;}
 	.filter-name {
 		margin-right: 0.25em;
-		color: #6B6B6B; // DACCESS-488 - accessibility color contrast
+		color: #6B6B6B !important; // DACCESS-488 - accessibility color contrast
 	}
 	.label {
 		display: inline;


### PR DESCRIPTION
I needed to add `!important` to this rule to override the existing one.