### PR TITLE
Bump openssl, libkrb5-3 versions in dockerfile

### DIFF
--- a/docker/bookworm/Dockerfile
+++ b/docker/bookworm/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
     default-libmysqlclient-dev=1.1.0 cron \
     # CVE-2024-5535
-    openssl=3.0.15-1~deb12u1 \
+    openssl=3.0.16-1~deb12u1 \
     # CVE-2024-37371
-    libkrb5-3=1.20.1-2+deb12u2 \
+    libkrb5-3=1.20.1-2+deb12u3 \
     # CVE-2024-33599
     libc6=2.36-9+deb12u10 \
     # CVE-2024-0567

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
             steps {
                 echo "The branch is ${env.GIT_BRANCH}"
                 echo "Running Cucumber tests with ${params.NUM_PROCESSES} processes"
-                timeout(90) {
+                timeout(120) {
                     wrap([$class: 'Xvfb', additionalOptions: '', assignedLabels: '', autoDisplayName: true, debug: true, displayNameOffset: 0, installationName: 'default', parallelBuild: true, screen: '1024x758x24', timeout: 25]) {
                         sh """
                             export FEATURE=${params.CUCUMBER_FEATURE_TESTS}


### PR DESCRIPTION
Resolves container build errors from newer debian package versions.

More info in d&a channel on slack.