### PR TITLE
DACCESS-571: fix position of modify advanced search button

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
@@ -186,6 +186,13 @@
 		font-weight: 700;
 	}
 }
+
+// Add a little space under each constraint for when they wrap onto multiple lines
+.selected-facets {
+	.btn {
+		margin-bottom: 5px;
+	}
+}
 .selected-facet {
 	padding: 0 10px;
 	background: $cornell-blue;
@@ -205,7 +212,9 @@
 }
 
 .modify-search-link {
-	float: right;
+	@include media-breakpoint-up(md) {
+		float: right;
+	}
 }
 
 // MEDIA QUERIES

--- a/blacklight-cornell/app/views/catalog/_constraints.html.erb
+++ b/blacklight-cornell/app/views/catalog/_constraints.html.erb
@@ -4,7 +4,7 @@
   <div class="selected-facets">
     <% if advanced_search? && params[:action] != 'edit'%>
       <div class="modify-search-link">
-        <%= link_to 'Modify advanced search &raquo;'.html_safe, url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive]), :class=>"btn btn-search" %>
+        <%= link_to 'Modify advanced search »', url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive]), :class=>"btn btn-outline-secondary" %>
       </div>
     <% end %>
   	<%=link_to t('blacklight.search.start_over'), url_for(:action=>'index'), :id=>"startOverLink", :class=>"btn btn-light" %>

--- a/blacklight-cornell/app/views/catalog/_constraints.html.erb
+++ b/blacklight-cornell/app/views/catalog/_constraints.html.erb
@@ -4,7 +4,7 @@
   <div class="selected-facets">
     <% if advanced_search? && params[:action] != 'edit'%>
       <div class="modify-search-link">
-        <%= link_to 'Modify advanced search »', url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive]), :class=>"btn btn-outline-secondary" %>
+        <%= link_to 'Modify advanced search »', url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive]), :class=>"btn btn-search" %>
       </div>
     <% end %>
   	<%=link_to t('blacklight.search.start_over'), url_for(:action=>'index'), :id=>"startOverLink", :class=>"btn btn-light" %>

--- a/blacklight-cornell/app/views/catalog/_constraints.html.erb
+++ b/blacklight-cornell/app/views/catalog/_constraints.html.erb
@@ -2,23 +2,21 @@
 <% params[:q] = params[:show_query] if  params[:show_query]%>
 <% if params[:action] != 'edit' && query_has_constraints? || params[:range].present? %>
   <div class="selected-facets">
+    <% if advanced_search? && params[:action] != 'edit'%>
+      <div class="modify-search-link">
+        <%= link_to 'Modify advanced search &raquo;'.html_safe, url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive]), :class=>"btn btn-search" %>
+      </div>
+    <% end %>
   	<%=link_to t('blacklight.search.start_over'), url_for(:action=>'index'), :id=>"startOverLink", :class=>"btn btn-light" %>
     <span class="constraints-label hidden"><% t('blacklight.search.filters.title') %></span>
     <% if params[:q_row].nil? && params[:f].nil? && params[:f_inclusive].nil? %>
-        <% if params[:search_field] && params[:search_field] != 'advanced'%>
-    	     <%= render_constraints_cts(params) %>
-        <% end %>
+      <% if params[:search_field] && params[:search_field] != 'advanced'%>
+          <%= render_constraints_cts(params) %>
+      <% end %>
     <% elsif params[:search_field] && params[:search_field] == 'advanced'%>
-    <%= render_advanced_constraints_query(params) %>
-
+      <%= render_advanced_constraints_query(params) %>
     <% else %>
-    <%= render_constraints(params) %>
-
-    <% end %>
-  <% if advanced_search? && params[:action] != 'edit'%>
-  <div class="modify-search-link">
-        <%= link_to 'Modify advanced search', url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive]), :class=>"btn btn-search" %>
-      </div>
+      <%= render_constraints(params) %>
     <% end %>
   </div>
   <% params[:q] = params[:y]%>


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-571

When you have a few constraints which stretch across the page or wrap onto multiple lines, the 'modify advanced search' button is positioned underneath them and looks weird. This floats the button right for desktop screens.

Also added some space under each constraint for when they wrap onto multiple lines.