### PR TITLE
DACCESS-410 Add helper method for creating and encoding browse urls

### DIFF
--- a/blacklight-cornell/app/helpers/browse_helper.rb
+++ b/blacklight-cornell/app/helpers/browse_helper.rb
@@ -1,15 +1,13 @@
 module BrowseHelper
 
-def browse_uri_encode (link_url)
-    link_url = link_url.gsub('&','%26')
-    link_url = link_url.gsub('"','%22')
-end
-	
-def call_number_browse_link(call_number)
-	link_url = '/browse?start=0&browse_type=Call-Number&authq=' + call_number
-	link_to(h(call_number), link_url)
-end
-
+  def browse_url(authq, browse_type, start=0, order=nil)
+    url = "/browse?authq=#{CGI.escape authq}&browse_type=#{browse_type}&start=#{start}"
+    if order.present?
+      url += "&order=#{order}"
+    end
+    return url
+  end
+  
   def cleanup_bio_data(bd)
     bd.reject { |k, v| k == 'Field' if bd.key?('Occupation') }
   end

--- a/blacklight-cornell/app/views/browse/_author_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_author_info.html.erb
@@ -40,7 +40,9 @@
 					<ul class='agent-notes'>
 						<% the_notes.each do |n| %>
 							<% if n.class.inspect == 'Hash'%>
-								<li><a href="/browse?authq=<%=n['header']%>&start=0&browse_type=Author"><%= n['header']%></a></li>
+								<li>
+									<%= link_to n['header'], browse_url(n['header'], 'Author') %>
+								</li>
 							<% end %>
 						<% end %>
 					</ul>
@@ -52,7 +54,7 @@
 				<% if pseudonym.present? %>
 					<dt>Pseudonym for:</dt>
 					<dd>
-						<a href="/browse?authq=<%=pseudonym%>&start=0&browse_type=Author"><%=pseudonym%></a>
+						<%= link_to pseudonym, browse_url(pseudonym, 'Author') %>
 					</dd>
 				<% end %>
 			<% end %>

--- a/blacklight-cornell/app/views/browse/_author_title_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_author_title_info.html.erb
@@ -26,7 +26,9 @@
 					<ul class='agent-notes'>
 					<% the_notes.each do |n| %>
 						<% if n.class.inspect == 'Hash'%>
-							<li><a href="/browse?authq=<%=n['header']%>&start=0&browse_type=Author"><%= n['header']%></a></li>
+							<li>
+								<%= link_to n['header'], browse_url(n['header'], 'Author') %>
+							</li>
 						<% end %>
 					<% end %>
 					</ul>

--- a/blacklight-cornell/app/views/browse/_availability_location_filter.html.erb
+++ b/blacklight-cornell/app/views/browse/_availability_location_filter.html.erb
@@ -4,7 +4,7 @@
     <% 
 	  start = params.has_key?(:start) ? params[:start] : 0
 	  order = params.has_key?(:order) ? params[:order] : 'forward'
-      url = "/browse?authq=#{params[:authq]}&browse_type=virtual&order=#{order}&start=#{start}"%>
+      url = browse_url(params[:authq], 'virtual', start, order)%>
       <label for="vb-lib-select" class="sr-only">Select library</label>
       <select id="vb-lib-select" class="form-control w-100" onchange="location = this.value;">
           <% @browse_locations.each do |lib| %>

--- a/blacklight-cornell/app/views/browse/_heading.html.erb
+++ b/blacklight-cornell/app/views/browse/_heading.html.erb
@@ -79,7 +79,7 @@
                           <% h.each do |headingInfo| %>
 							<% if loop_count < 4 %>
                             	<li style="display:inline;padding-left:6px">
-                            	  <%= link_to "/browse?authq=" + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + "&start=0" + "&browse_type=" + params[:browse_type] do %>
+                                <%= link_to browse_url(headingInfo["heading"].gsub('&', '%26').gsub("\"", "'"), params[:browse_type]) do %>
                             	    <%= headingInfo["heading"] %>
 								  <% end %>
                             	  <span class="see-ref-count"><%= "(" + headingInfo["count"].to_s + ")"  %></span>
@@ -102,7 +102,7 @@
                     <% else %>
                       <% h.each do |headingInfo| %>
                         <div class="see-also-author-title">
-                          <%= link_to "/browse?authq=" + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + "&start=0" + "&browse_type=" + params[:browse_type] do %>
+                          <%= link_to browse_url(headingInfo["heading"].gsub('&', '%26').gsub("\"", "'"), params[:browse_type]) do %>
                                 <%= headingInfo["heading"] %><% end %>
                               <%= "(" + headingInfo["count"].to_s + ")"  %>
                         </div>
@@ -119,7 +119,7 @@
                   <div class="see-ref">
                     <i class="fa fa-arrow-right"></i>
                     See
-                    <%= link_to '/browse?authq=' + form["heading"].gsub('&', '%26') + '&start=0' +"&browse_type=" + params[:browse_type] do %>
+                    <%= link_to browse_url(form["heading"].gsub('&', '%26').gsub("\"", "'"), params[:browse_type]) do %>
                       <%= form["heading"] %><% end %>
                     <div class="see-ref-count">
                       <%= "(" + form["count"].to_s + ")" %>

--- a/blacklight-cornell/app/views/browse/_pagination.html.erb
+++ b/blacklight-cornell/app/views/browse/_pagination.html.erb
@@ -17,12 +17,12 @@
       <% if !@has_previous %>
         &laquo; Previous |
       <% elsif params[:order] != "reverse" %>
-        <%= link_to "/browse?authq=" + params[:authq] + "&start=0" +"&browse_type=" + params[:browse_type] + '&order=reverse' + location do %>
+        <%= link_to browse_url(params[:authq], params[:browse_type], 0, "reverse") + location do %>
           &laquo; Previous 
         <% end %>
         | 
       <% else %>
-        <%= link_to "/browse?authq=" + params[:authq] + "&start=" + previous +"&browse_type=" + params[:browse_type] + '&order=reverse' + location do %>
+        <%= link_to browse_url(params[:authq], params[:browse_type], previous, "reverse") + location do %>
           &laquo; Previous 
         <% end %>
         | 
@@ -30,22 +30,21 @@
       <% if !@has_next%>
         Next &raquo;
       <% elsif params[:order] != "reverse" %>
-        <%= link_to "/browse?authq=" + params[:authq] + "&start=" + nextpage +"&browse_type=" + params[:browse_type] + '&order=forward' + location do %>
+        <%= link_to browse_url(params[:authq], params[:browse_type], nextpage, "forward") + location do %>
           Next &raquo;
         <% end %>
       <% else %>
-        <%= link_to "/browse?authq=" + params[:authq] + "&start=0" + "&browse_type=" + params[:browse_type] + '&order=forward' + location do %>
+        <%= link_to browse_url(params[:authq], params[:browse_type], 0, "forward") + location do %>
           Next &raquo;        
         <% end %>
       <% end %>
     <% else   %>
       <% if !params[:authq].nil? and !params[:browse_type].nil? and !params[:order].nil? %>
-      
-        <%= link_to "/browse?authq=" + params[:authq] + "&start=" + previous +"&browse_type=" + params[:browse_type] +  "&order=" + params[:order] + location do %>
+        <%= link_to browse_url(params[:authq], params[:browse_type], previous, params[:order]) + location do %>
           &laquo; Previous 
         <% end %>
-      | 
-        <%= link_to "/browse?authq=" + params[:authq] + "&start=" + nextpage +"&browse_type=" + params[:browse_type] + "&order=" + params[:order] + location do %>
+        | 
+        <%= link_to browse_url(params[:authq], params[:browse_type], nextpage, params[:order]) + location do %>
           Next &raquo;
         <% end %>
       <% end %>

--- a/blacklight-cornell/app/views/browse/_reference_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_reference_info.html.erb
@@ -23,7 +23,7 @@
       <% loop_count = 0 %>
       <% h.each do |headingInfo| %>
         <dd <% if h.count > 20 and loop_count >= 20 %>style="margin-left:0;display:none;"  class="toggled-cr-refs"<% elsif h.count > 20  %>style="margin-left:0;"<%end%>>
-        <%= link_to "/browse?authq=" + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + "&start=0" + "&browse_type=" + params[:browse_type] do %>
+        <%= link_to browse_url(headingInfo["heading"].gsub('&', '%26').gsub("\"", "'"), params[:browse_type]) do %>
           <%= headingInfo["heading"] %>
         <% end %>
         <% if headingInfo["worksBy"].present? %>

--- a/blacklight-cornell/app/views/browse/_virtual_browse.html.erb
+++ b/blacklight-cornell/app/views/browse/_virtual_browse.html.erb
@@ -55,10 +55,10 @@
 	  <div id="outer-container" class="slides-full" tabindex="0">
 		<div class="inner-container" id="prev-reroute" style="display:none;">
 			<div class="vb-reroute">
-				<a href="/browse?authq=<%=response[0]['callnumber']%>&browse_type=virtual">
+				<%= link_to browse_url(response[0]['callnumber'],"virtual") do %>
 					<div> <i class="fa fa-chevron-left"></i> </div>
 					<div> View more browse results</div>
-				</a>
+				<% end %>
 			</div>
 		</div>
 	<% count = 0 %>
@@ -109,10 +109,10 @@
 	<% end %>
 	<div class="inner-container" id="next-reroute" style="display:none">
 		<div class="vb-reroute"><%# [response.size-1] %>
-			<a href="/browse?authq=<%=response[response.size-1]['callnumber']%>&browse_type=virtual">
+			<%= link_to browse_url(response[response.size-1]['callnumber'],"virtual") do %>
 				<div>View more browse results </div>
 				<div> <i class="fa fa-chevron-right"></i></div>
-			</a>
+			<% end %>
 		</div>
 	</div>
   </div>

--- a/blacklight-cornell/app/views/browse/info.html.erb
+++ b/blacklight-cornell/app/views/browse/info.html.erb
@@ -9,7 +9,7 @@
           Back to item
         <% end %>        
       <% else %>
-        <%= link_to "/browse?authq=#{CGI.escape(params[:authq])}&browse_type=#{params[:browse_type]}&start=0" do %>
+        <%= link_to browse_url(params[:authq],params[:browse_type]) do %>
           <i class="fa fa-arrow-circle-left"></i>
           Back to list
         <% end %>

--- a/blacklight-cornell/app/views/catalog/_call_number_browse_links.html.erb
+++ b/blacklight-cornell/app/views/catalog/_call_number_browse_links.html.erb
@@ -22,7 +22,7 @@
 
 		<div class="browse-buttons">
 	      <% callnumbers.each do |callnumber| %>
-	          <%= link_to callnumber, '/browse?' + {:browse_type => 'Call-Number', :authq => callnumber}.to_query, {:class => "btn btn-cul mb-2"} %>
+			<%= link_to callnumber, browse_url(callnumber, "Call-Number"), {:class => "btn btn-cul my-1"} %>
 	      <% end %>
 	    </div>
     </div>
@@ -42,7 +42,9 @@
 	%>
 	<div class="">
 	  <div id="classification" class="row class-heading" data-anchor-label="<%= internal_class%>" data-keep-count="true" data-next-count="0" data-prev-count="0">
-        <div class="vb-browse-link"><a href="/browse?authq=<%=callnumbers[0]%>&browse_type=virtual" onclick="javascript:_paq.push(['trackEvent', 'virtualbrowse_itemview', 'expanded_view_link']);">Expanded view</a></div>
+        <div class="vb-browse-link">
+	  		<%= link_to "Expanded view", browse_url(callnumbers[0], "virtual"), {:onclick => "javascript:_paq.push(['trackEvent', 'virtualbrowse_itemview', 'expanded_view_link']);"} %>
+		</div>
         <div class="vb-scroll-nav">
 	        <a id="vb-scroll-left" href="javascript:void(0);" rel="scroll-left" onclick="javascript:_paq.push(['trackEvent', 'virtualbrowse_itemview', 'scroll_left']);">
 		        <span class="fa fa-chevron-left" aria-hidden="true"></span>


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-410

This issue originated with a bug ticket related to encoding the "Expanded View" link to the virtual browse. Upon further investigation, I determined that links to the browse features more broadly could use some cleanup. This resulted in the following changes: 

- Removing unused browse helper methods, browse_uri_encode and call_number_browse_link
- Adding new helper method for creating and encoding browse urls for all browse types
- Updating existing browse links in views with new method

I'm open to suggestions if there is a better approach than adding a helper method here. 