### PR TITLE
Remove pub year value placeholders values in advanced search form

### DIFF
--- a/blacklight-cornell/app/components/advanced_range_limit_component.html.erb
+++ b/blacklight-cornell/app/components/advanced_range_limit_component.html.erb
@@ -2,9 +2,9 @@
   <%= label_tag "#{field}", :class => 'col-form-label col-lg-4' do %><%= label %><% end %>
   <div class="col-lg-8 form-inline">
     <%= label_tag("range[#{field}][begin]", 'from year', class: 'sr-only visually-hidden') %>
-    <%= number_field_tag("range[#{field}][begin]", begin_val, maxlength: 6, placeholder: 0, class: 'form-control text-center range_begin') %>
+    <%= number_field_tag("range[#{field}][begin]", begin_val, maxlength: 6, class: 'form-control text-center range_begin') %>
     <span class="col-form-label"> - </span>
     <%= label_tag("range[#{field}][end]", 'to year', class: 'sr-only visually-hidden') %>
-    <%= number_field_tag("range[#{field}][end]", end_val, maxlength: 6, placeholder: Time.now.year + 1, class: 'form-control text-center range_end') %>
+    <%= number_field_tag("range[#{field}][end]", end_val, maxlength: 6, class: 'form-control text-center range_end') %>
   </div>
 </div>

--- a/blacklight-cornell/app/components/advanced_range_limit_component.rb
+++ b/blacklight-cornell/app/components/advanced_range_limit_component.rb
@@ -4,11 +4,11 @@ class AdvancedRangeLimitComponent < Blacklight::Component
   end
 
   def label
-   "#{@facet_field.facet_field.label} Range"
+    "#{@facet_field.label} Range"
   end
 
   def field
-    @facet_field.facet_field.field
+    @facet_field.key
   end
 
   def begin_val

--- a/blacklight-cornell/spec/components/advanced_range_limit_component_spec.rb
+++ b/blacklight-cornell/spec/components/advanced_range_limit_component_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe AdvancedRangeLimitComponent, type: :component do
+  subject(:component) { described_class.new(facet_field: facet_field) }
+
+  let(:rendered) { Capybara::Node::Simple.new(render_inline(component)) }
+
+  let(:facet_field) do
+    instance_double(
+      BlacklightRangeLimit::FacetFieldPresenter,
+      key: 'pub_date_facet',
+      label: 'Publication Year',
+      search_state: BlacklightCornell::SearchState.new(facet_field_params, nil),
+      facet_field: facet_config
+    )
+  end
+
+  let(:facet_config) do
+    Blacklight::Configuration::FacetField.new(key: 'pub_date_facet', item_presenter: BlacklightRangeLimit::FacetItemPresenter)
+  end
+
+  let(:facet_field_params) { {} }
+
+  it 'renders the range field label' do
+    expect(rendered).to have_selector('label.col-form-label', text: 'Publication Year Range')
+  end
+
+  it 'render empty input fields' do
+    expect(rendered.find('input#range_pub_date_facet_begin').value).to be_nil
+    expect(rendered.find('input#range_pub_date_facet_end').value).to be_nil
+  end
+
+  context 'with range params' do
+    let(:facet_field_params) do
+      {
+        range: {
+          pub_date_facet: {
+            begin: '2000',
+            end: '2020'
+          }
+        }
+      }
+    end
+
+    it 'prefills inputs from range params' do
+      expect(rendered).to have_field('range_pub_date_facet_begin', with: '2000')
+      expect(rendered).to have_field('range_pub_date_facet_end', with: '2020')
+    end
+  end
+
+  context 'with empty range params' do
+    let(:facet_field_params) do
+      {
+        range: {
+          pub_date_facet: {
+            begin: '',
+            end: ''
+          }
+        }
+      }
+    end
+
+    it 'renders empty input fields' do
+      expect(rendered).to have_field('range_pub_date_facet_begin', with: '')
+      expect(rendered).to have_field('range_pub_date_facet_end', with: '')
+    end
+  end
+end

--- a/blacklight-cornell/spec/rails_helper.rb
+++ b/blacklight-cornell/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require_relative '../features/support/selenium'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'view_component/test_helpers'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -75,4 +76,7 @@ RSpec.configure do |config|
   #     puts "Saved HTML to tmp/capybara/failed_test.html"
   #   end
   # end
+
+  # Enable ViewComponent test helpers
+  config.include ViewComponent::TestHelpers, type: :component
 end


### PR DESCRIPTION
Based on conversation in slack: don't use placeholders for pub year range facet fields in advanced search form.

Also adds ViewComponent rspec configuration for future component specs.