### PR TITLE
Layout updates for browse show pages

### DIFF
--- a/blacklight-cornell/app/assets/javascripts/linked_data/author_browse.js
+++ b/blacklight-cornell/app/assets/javascripts/linked_data/author_browse.js
@@ -136,7 +136,7 @@ function AuthorBrowse() {
     if (image) {
       $('#bio-image').attr('src', image.url);
       $('#img-container').removeClass('d-none');;
-      $('#wiki-image-acknowledge').html(`<br/>Image: ${wikidataConnector.imageAttributionHtml(image)}`);
+      $('#wiki-image-acknowledge').html(`Image: ${wikidataConnector.imageAttributionHtml(image)}`);
     } else {
       $('#comment-container').removeClass();
       $('#comment-container').addClass('col-sm-12').addClass('col-md-12').addClass('col-lg-12');

--- a/blacklight-cornell/app/assets/javascripts/linked_data/author_title_browse.js
+++ b/blacklight-cornell/app/assets/javascripts/linked_data/author_title_browse.js
@@ -94,9 +94,7 @@ function AuthorTitleBrowse() {
   function generateWikidataSourceLinks(data) {
     if (!('entity' in data)) return '';
     return (
-      `  <span class="ld-acknowledge">
-        * <a href="${data.entity}">From Wikidata<i class="fa fa-external-link" aria-hidden="true"></i></a>
-      </span>`
+      `* <a href="${data.entity}">From Wikidata<i class="fa fa-external-link" aria-hidden="true"></i></a>`
     );
   }
 

--- a/blacklight-cornell/app/assets/javascripts/linked_data/subject_browse.js
+++ b/blacklight-cornell/app/assets/javascripts/linked_data/subject_browse.js
@@ -7,11 +7,11 @@ function SubjectBrowse() {
     $('#cr-refs-toggle').click(function() {
       if ( $('.toggled-cr-refs').first().is(':visible') ) {
         $('.toggled-cr-refs').hide();
-        $('#cr-refs-toggle').html('more &raquo;');
+        $('#cr-refs-toggle').html('Show more &raquo;');
       }
       else {
         $('.toggled-cr-refs').show();
-        $('#cr-refs-toggle').html('&laquo; less');
+        $('#cr-refs-toggle').html('&laquo; Show less');
       }
       return false;
     });
@@ -104,7 +104,7 @@ function SubjectDataBrowse() {
     if (image) {
       $('#bio-image').attr('src', image.url);
       $('#img-container').removeClass('d-none');;
-      $('#wiki-image-acknowledge').html(`<br/>Image: ${wikidataConnector.imageAttributionHtml(image)}`);
+      $('#wiki-image-acknowledge').html(`Image: ${wikidataConnector.imageAttributionHtml(image)}`);
     } else {
       $('#comment-container').removeClass();
       $('#comment-container').addClass('col-sm-12').addClass('col-md-12').addClass('col-lg-12');

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss
@@ -39,7 +39,7 @@ footer {
 // ------------------------
 
 h2 { 
-	margin-bottom: .5em;
+	margin: 1rem 0;
 	font-size: 26px;
 }
 h3 { font-size: 20px; line-height: 1.5em;}

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_browse-info.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_browse-info.scss
@@ -12,13 +12,6 @@ ul.nav-tabs li {
     background: #edebe7;
     border-bottom:1px solid #dee2e6;
 }
-#bio-with-ld {
-  background: #edebe7;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  border: 1px solid rgba(0, 0, 0, 0.125);
-  border-radius: 0.25rem;
-}
 #ref-info-heading, #lcnaf-link {
   padding: 10px 0 0 0;
 }
@@ -27,9 +20,16 @@ ul.nav-tabs li {
   margin-bottom: 16px;
 }
 .ld-acknowledge {
-    font-size: 14px;
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid $tan;
+    font-size: .8rem;
     i {
         margin-left: .25rem;
+    }
+    span {
+        margin-bottom: .5rem;
+        display: inline-block;
     }
 }
 #item-details > dt {

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_browse-info.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_browse-info.scss
@@ -19,10 +19,12 @@ ul.nav-tabs li {
   display: none;
   margin-bottom: 16px;
 }
-.ld-acknowledge {
+div.ld-acknowledge {
     margin-top: 2rem;
     padding-top: 1rem;
     border-top: 1px solid $tan;
+}
+.ld-acknowledge {
     font-size: .8rem;
     i {
         margin-left: .25rem;

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_browse-info.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_browse-info.scss
@@ -40,3 +40,14 @@ ul.nav-tabs li {
         margin-left: .25rem;
     }
 }
+#bio-with-ld {
+    img {
+        max-width: 200px;
+    }
+    // Medium devices (tablets, 768px and up)
+    @include media-breakpoint-up(md) {
+        img {
+            max-width: 100%;
+        }
+    }
+}

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_headings.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_headings.scss
@@ -1,3 +1,20 @@
+// Typography
+// ------------------------
+
+.browse {
+	h3 {
+		border-bottom: 1px solid $tan;
+		padding-bottom: .25rem;
+		margin-bottom: 1.5rem;
+	}
+	.card-header {
+		h3 {
+			border-bottom: 0;
+		}
+	}
+}
+
+
 // Headings browse-search box
 // ------------------------------------------
 .browse-index {

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_headings.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_headings.scss
@@ -1,7 +1,8 @@
 // Typography
 // ------------------------
 
-.browse {
+.browse,
+.blacklight-browse {
 	h3 {
 		border-bottom: 5px solid $light-tan;
 		padding-bottom: .25rem;

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_headings.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_headings.scss
@@ -3,7 +3,7 @@
 
 .browse {
 	h3 {
-		border-bottom: 1px solid $tan;
+		border-bottom: 5px solid $light-tan;
 		padding-bottom: .25rem;
 		margin-bottom: 1.5rem;
 	}

--- a/blacklight-cornell/app/views/browse/_author_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_author_info.html.erb
@@ -9,7 +9,7 @@
 <input id='exclusions' type='hidden' value="<%= exclusions_JSON %>" />
 
 <div class='row info-row mb-4 mt-4'>
-  <div id='left-container' class='col-8'>
+  <div id='left-container' class='col-sm-8'>
 		<%= render 'bio_info', heading_type: 'author', bio_data: bio_data do %>
 			<% if bio_data['Occupation'].present? %>
 				<dt>Occupation:</dt>
@@ -61,7 +61,7 @@
       <%= render 'reference_info' %>
     </div>
 	</div>
-	<div class='col-4'>
+	<div class='col-sm-4'>
 		<%= render 'holdings' %>
 		<%# Will display relevant call numbers for the author if they're available. %>
 		<div id='callnumberbrowselink' class='mb-4 mt-4 ml-2' localname="<%=@loc_localname.gsub('"','')%>"></div>

--- a/blacklight-cornell/app/views/browse/_author_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_author_info.html.erb
@@ -9,7 +9,7 @@
 <input id='exclusions' type='hidden' value="<%= exclusions_JSON %>" />
 
 <div class='row info-row mb-4 mt-4'>
-  <div id='left-container' class='col-sm-8 col-md-8 col-lg-8'>
+  <div id='left-container' class='col-8'>
 		<%= render 'bio_info', heading_type: 'author', bio_data: bio_data do %>
 			<% if bio_data['Occupation'].present? %>
 				<dt>Occupation:</dt>
@@ -61,7 +61,7 @@
       <%= render 'reference_info' %>
     </div>
 	</div>
-	<div class='col-sm-4 col-md-4 col-lg-4'>
+	<div class='col-4'>
 		<%= render 'holdings' %>
 		<%# Will display relevant call numbers for the author if they're available. %>
 		<div id='callnumberbrowselink' class='mb-4 mt-4 ml-2' localname="<%=@loc_localname.gsub('"','')%>"></div>

--- a/blacklight-cornell/app/views/browse/_author_title_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_author_title_info.html.erb
@@ -3,7 +3,6 @@
   bio_data = @heading_document['rda_json'].present? ? JSON.parse(@heading_document['rda_json']) : {}
 	display_info_details = bio_data.present? || @heading_document['notes'].present?
 %>
-<h1><%=@heading_document['headingTypeDesc']%></h1>
 
 <div id='author-title-heading' class='row info-row mb-4 mt-4' data-heading="<%=encoded_heading%>" >
   <div id='left-container' class='col-sm-8'>

--- a/blacklight-cornell/app/views/browse/_author_title_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_author_title_info.html.erb
@@ -6,7 +6,7 @@
 <h1><%=@heading_document['headingTypeDesc']%></h1>
 
 <div id='author-title-heading' class='row info-row mb-4 mt-4' data-heading="<%=encoded_heading%>" >
-  <div id='left-container' class='col-8'>
+  <div id='left-container' class='col-sm-8'>
 		<%= render 'bio_info', heading_type: 'authortitle', bio_data: bio_data do %>
       <% if bio_data.present? %>
 				<%
@@ -37,7 +37,7 @@
       <%= render partial: 'reference_info' %>
     </div>
 	</div>
-	<div class='col-4'>
+	<div class='col-sm-4'>
 		<%= render 'holdings' %>
 	</div>
 </div>

--- a/blacklight-cornell/app/views/browse/_author_title_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_author_title_info.html.erb
@@ -6,7 +6,7 @@
 <h1><%=@heading_document['headingTypeDesc']%></h1>
 
 <div id='author-title-heading' class='row info-row mb-4 mt-4' data-heading="<%=encoded_heading%>" >
-  <div id='left-container' class='col-sm-8 col-md-8 col-lg-8'>
+  <div id='left-container' class='col-8'>
 		<%= render 'bio_info', heading_type: 'authortitle', bio_data: bio_data do %>
       <% if bio_data.present? %>
 				<%
@@ -37,7 +37,7 @@
       <%= render partial: 'reference_info' %>
     </div>
 	</div>
-	<div class='col-sm-4 col-md-4 col-lg-4'>
+	<div class='col-4'>
 		<%= render 'holdings' %>
 	</div>
 </div>

--- a/blacklight-cornell/app/views/browse/_bio_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_bio_info.html.erb
@@ -2,7 +2,7 @@
 <% if bio_data.present? %>
   <div id='bio-without-ld' class='d-none'>
     <h3>Description</h3>
-    <dl class='dl-horizontal ml-3'>
+    <dl class='dl-horizontal'>
       <%= render_bio_data(bio_data) %>
     </dl>
   </div>

--- a/blacklight-cornell/app/views/browse/_bio_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_bio_info.html.erb
@@ -13,10 +13,10 @@
   <div class='card card-well'>
     <div class='card-body'>
       <div class='row'>
-        <div id='img-container' class='col-sm-5 col-md-4 col-lg-3 text-center d-none'>
+        <div id='img-container' class='col-md-4 col-lg-3 text-center d-none'>
           <img id='bio-image' src='' title="<%= heading_type %> image" alt='' class='img-fluid mb-4'>
         </div>
-        <div id='comment-container' class='col-sm-7 col-md-8 col-lg-9'>
+        <div id='comment-container' class='col-md-8 col-lg-9'>
           <div id='dbp-comment'></div>
           <dl class='dl-horizontal' id='item-details'>
             <%# display different data per heading type in <HEADING_TYPE>_info.html.erb %>

--- a/blacklight-cornell/app/views/browse/_bio_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_bio_info.html.erb
@@ -9,20 +9,26 @@
 <% end %>
 
 <%# js displays this section in grey box if linked data found %>
-<div id='bio-with-ld' class='row info-row ml-0 d-none'>
-  <div id='img-container' class='col-sm-5 col-md-4 col-lg-3 text-center d-none'>
-    <img id='bio-image' src='' title="<%= heading_type %> image" width='120px'/><br/>
-  </div>
-  <div id='comment-container' class='col-sm-7 col-md-8 col-lg-9'>
-  <div id='dbp-comment'></div>
-    <dl class='dl-horizontal' id='item-details'>
-      <%# display different data per heading type in <HEADING_TYPE>_info.html.erb %>
-      <%= yield %>
-    </dl>
-    <%# filled in by javascript when needed %>
-    <div class='text-right ld-acknowledge'>
-      <span id='wiki-acknowledge'></span>
-      <span id='wiki-image-acknowledge'></span>
+<div id='bio-with-ld' class='d-none'>
+  <div class='card card-well'>
+    <div class='card-body'>
+      <div class='row'>
+        <div id='img-container' class='col-sm-5 col-md-4 col-lg-3 text-center d-none'>
+          <img id='bio-image' src='' title="<%= heading_type %> image" alt='' class='img-fluid mb-4'>
+        </div>
+        <div id='comment-container' class='col-sm-7 col-md-8 col-lg-9'>
+          <div id='dbp-comment'></div>
+          <dl class='dl-horizontal' id='item-details'>
+            <%# display different data per heading type in <HEADING_TYPE>_info.html.erb %>
+            <%= yield %>
+          </dl>
+          <%# filled in by javascript when needed %>
+          <div class='ld-acknowledge'>
+            <span id='wiki-acknowledge'></span>
+            <span id='wiki-image-acknowledge'></span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/blacklight-cornell/app/views/browse/_holdings.html.erb
+++ b/blacklight-cornell/app/views/browse/_holdings.html.erb
@@ -5,9 +5,9 @@
 
 <div class='card' id='formats'>
   <div class='card-header'>
-    <h3 style='margin-bottom: 0;'>Library Holdings</h3>
+    <h3 class='mb-0'>Library Holdings</h3>
   </div>
-  <div class='card-body' style='padding-top: .75rem;'>
+  <div class='card-body'>
     <ul class='fa-ul' id='more-results'>
       <% if works['works'].present? %>
         <li>

--- a/blacklight-cornell/app/views/browse/_holdings.html.erb
+++ b/blacklight-cornell/app/views/browse/_holdings.html.erb
@@ -20,7 +20,7 @@
       <% if works['worksBy'].present? %>
         <li>
           Total Works By:
-          <%= link_to "/?q=\"#{encoded_heading}\"&search_field=author_#{@heading_document.type}_browse" do %>
+          <%= link_to "/?q=\"#{encoded_heading}\"&search_field=author_#{@heading_document.type}_browse", aria: { label: "View all works by #{encoded_heading}" } do %>
             <%= pluralize(number_with_delimiter(works['worksBy']), 'Title') %>
           <% end %>
         </li>
@@ -28,9 +28,9 @@
       <% if works['worksAbout'].present? %>
         <li>
           Total Works About:
-          <%= link_to "/?q=\"#{encoded_heading}\"&search_field=subject_#{@heading_document.type}_browse" do %>
-            <%= pluralize(number_with_delimiter(works['worksAbout']), 'Title') %>
-          <% end %>
+          <%= link_to "/?q=\"#{encoded_heading}\"&search_field=subject_#{@heading_document.type}_browse", aria: { label: "View all works about #{encoded_heading}" } do %>
+          <%= pluralize(number_with_delimiter(works['worksAbout']), 'Title') %>
+        <% end %>
         </li>
       <% end %>
       <li style='text-align center'>

--- a/blacklight-cornell/app/views/browse/_reference_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_reference_info.html.erb
@@ -5,7 +5,7 @@
       @heading_document['headingTypeDesc'].present? ||
       !@loc_localname.blank? %>
 <h3>Reference Information</h3>
-<div id='reference-info' class='col-sm-12 col-md-12 col-lg-12'>
+<div id='reference-info'>
   <%# display any seeAlso info first %>
   <% if @heading_document["seeAlso"].present?  %>
     <dl class="dl-horizontal">

--- a/blacklight-cornell/app/views/browse/_reference_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_reference_info.html.erb
@@ -48,7 +48,7 @@
       <% end %>
   	  <% if loop_count > 20 %>
   	    <div>
-  	      <a id="cr-refs-toggle" href="#">more &raquo;</a>
+  	      <a id="cr-refs-toggle" href="#" class="btn btn-sm btn-outline-secondary">Show more &raquo;</a>
   	    </div>
   	  <% end %>
   	  <% if h.count >= 20 %>

--- a/blacklight-cornell/app/views/browse/_reference_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_reference_info.html.erb
@@ -37,7 +37,8 @@
         <% if headingInfo["worksAbout"].present? %>
           <span class="author-works">
             Works about:
-            <%= link_to '/?q="' + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + '"&search_field=subject_' + @heading_document.type_for_desc(headingInfo["headingTypeDesc"]) + '_browse' do %>
+            <%= link_to '/?q="' + headingInfo["heading"].gsub('&', '%26').gsub("\"", "'") + '"&search_field=subject_' + @heading_document.type_for_desc(headingInfo["headingTypeDesc"]) + '_browse',
+            aria: { label: "View all works about #{headingInfo['heading']}" } do %>
               <%= headingInfo["worksAbout"] %>
             <% end %>
           </span>

--- a/blacklight-cornell/app/views/browse/_subject_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_subject_info.html.erb
@@ -10,7 +10,7 @@
 <input id='exclusions' type='hidden' value="<%= exclusions_JSON %>" />
 
 <div class='row info-row mb-4 mt-4'>
-  <div id='left-container' class='col-sm-8 col-md-8 col-lg-8'>
+  <div id='left-container' class='col-8'>
     <%= render 'bio_info', heading_type: 'subject', bio_data: bio_data do %>
       <%= render_bio_data(bio_data) if bio_data.present? %>
     <% end %>
@@ -18,7 +18,7 @@
       <%= render partial: 'reference_info' %>
     </div>
   </div>
-	<div class='col-sm-4 col-md-4 col-lg-4'>
+	<div class='col-4'>
     <%= render 'holdings' %>
     <%# Will display relevant call numbers for the subject if they're available. %>
     <div id='callnumberbrowselink' class='mb-4 mt-4 ml-2' localname="<%=@loc_localname.gsub('"','')%>"></div>

--- a/blacklight-cornell/app/views/browse/_subject_info.html.erb
+++ b/blacklight-cornell/app/views/browse/_subject_info.html.erb
@@ -10,7 +10,7 @@
 <input id='exclusions' type='hidden' value="<%= exclusions_JSON %>" />
 
 <div class='row info-row mb-4 mt-4'>
-  <div id='left-container' class='col-8'>
+  <div id='left-container' class='col-sm-8'>
     <%= render 'bio_info', heading_type: 'subject', bio_data: bio_data do %>
       <%= render_bio_data(bio_data) if bio_data.present? %>
     <% end %>
@@ -18,7 +18,7 @@
       <%= render partial: 'reference_info' %>
     </div>
   </div>
-	<div class='col-4'>
+	<div class='col-sm-4'>
     <%= render 'holdings' %>
     <%# Will display relevant call numbers for the subject if they're available. %>
     <div id='callnumberbrowselink' class='mb-4 mt-4 ml-2' localname="<%=@loc_localname.gsub('"','')%>"></div>


### PR DESCRIPTION
Changes include:
- H3 styling to better chunk information
- Clean up grid styles
- Improve responsive display
- Replace custom styles with existing bootstrap styles
- Add aria labels to works by and about counts for more link context

Example records (local URLs):
- [Work info with LD box](http://0.0.0.0:9292/browse/info?authq=Beethoven%2C+Ludwig+van%2C+1770-1827.+%7C+Septet%2C+clarinet%2C+bassoon%2C+horn%2C+violin%2C+viola%2C+cello%2C+double+bass%2C+op.+20%2C+E%E2%99%AD+major&bib=8297109&browse_type=Author-Title)
- [Author with LD box](http://0.0.0.0:9292/browse/info?authq=Murakami%2C+Haruki%2C+1949-&browse_type=Author&headingtype=Personal%20Name)
- [Author no LD](http://0.0.0.0:9292/browse/info?authq=Beethoven%2C+Ludwig+van%2C+1770-1827.&browse_type=Author-Title)
- [Subject with LD box and 'more' button](http://0.0.0.0:9292/browse/info?authq=Motion%20pictures&browse_type=Subject&headingtype=Topical%20Term#)