### PR TITLE
Daccess 84 info buttons

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss
@@ -97,6 +97,12 @@ h3 { font-size: 20px; line-height: 1.5em;}
 		border-bottom: 1px solid $dark-green;
 	}
 }
+.btn-group-xs > .btn, .btn-xs {
+  padding: .25rem .4rem;
+  font-size: .875rem;
+  line-height: .5;
+  border-radius: .2rem;
+}
 
 // Card customization
 // ------------------------

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_item-record.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_item-record.scss
@@ -262,9 +262,19 @@ padding-left: 6em;
 }
 // Styles apply to item view and browse pages for Author, Author-Title, Subject
 .info-button {
-	margin-left: .25rem;
-	padding: .1rem .4rem;
+	margin-left: .4rem;
 	font-size: .8rem;
+}
+.info-button.btn-xs {
+	padding: .4rem .3rem;
+}
+
+// DACCESS-84: spacing for crowded Work info values + buttons
+.blacklight-included_work_display {
+	.info-button {
+		margin-bottom: .75rem;
+		margin-top: .25rem;
+	}
 }
 
 // Metadata

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_item-record.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_item-record.scss
@@ -266,7 +266,7 @@ padding-left: 6em;
 	font-size: .8rem;
 }
 .info-button.btn-xs {
-	padding: .4rem .3rem;
+	padding: .4rem .3rem .5rem .3rem;
 }
 
 // DACCESS-84: spacing for crowded Work info values + buttons

--- a/blacklight-cornell/app/helpers/display_helper.rb
+++ b/blacklight-cornell/app/helpers/display_helper.rb
@@ -315,7 +315,7 @@ end
                                       browse_info_path(authq: authq,
                                                        bib: args[:document]['id'],
                                                        browse_type: related_auth_label),
-                                      class: 'info-button d-inline-block btn btn-sm btn-outline-secondary',
+                                      class: 'info-button d-inline-block btn btn-xs btn-outline-secondary',
                                       'aria-label' => 'Work info for ' + authq)
                 search_link + browse_link
               else

--- a/blacklight-cornell/app/helpers/display_helper.rb
+++ b/blacklight-cornell/app/helpers/display_helper.rb
@@ -315,7 +315,8 @@ end
                                       browse_info_path(authq: authq,
                                                        bib: args[:document]['id'],
                                                        browse_type: related_auth_label),
-                                      class: 'info-button d-inline-block btn btn-sm btn-outline-secondary')
+                                      class: 'info-button d-inline-block btn btn-sm btn-outline-secondary',
+                                      'aria-label' => 'Work info for ' + authq)
                 search_link + browse_link
               else
                 search_link

--- a/blacklight-cornell/app/views/browse/_heading.html.erb
+++ b/blacklight-cornell/app/views/browse/_heading.html.erb
@@ -46,13 +46,13 @@
             <% if !data["seeAlso"].nil? || !data["notes"].nil?  || data["mainEntry"] == true %>
               <% unless params[:browse_type] == 'Author-Title' %>
 				<% if %>
-                  <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type]+"&headingtype=" + data["headingTypeDesc"], { :class => "info-button btn btn-sm btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);"} do %>
+                  <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type]+"&headingtype=" + data["headingTypeDesc"], { :class => "info-button btn btn-sm btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => 'Author info for ' +  data["heading"]} do %>
                       <%=params[:browse_type]%> info »
                   <% end %>
 				<% end %>
               <% end %>
               <% if params[:browse_type] == 'Author-Title' %>
-                <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type], { :class => "info-button btn btn-sm btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);"} do %>
+                <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type], { :class => "info-button btn btn-sm btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => 'Author-Title info for ' + data["heading"]} do %>
                     <%=params[:browse_type]%> info »
                 <% end %>
               <% end %>

--- a/blacklight-cornell/app/views/browse/_heading.html.erb
+++ b/blacklight-cornell/app/views/browse/_heading.html.erb
@@ -46,7 +46,7 @@
             <% if !data["seeAlso"].nil? || !data["notes"].nil?  || data["mainEntry"] == true %>
               <% unless params[:browse_type] == 'Author-Title' %>
 				<% if %>
-                  <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type]+"&headingtype=" + data["headingTypeDesc"], { :class => "info-button btn btn-xs btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => 'Author info for ' +  data["heading"]} do %>
+                  <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type]+"&headingtype=" + data["headingTypeDesc"], { :class => "info-button btn btn-xs btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => {params[:browse_type]} + ' info for ' +  data["heading"]} do %>
                       <%=params[:browse_type]%> info »
                   <% end %>
 				<% end %>

--- a/blacklight-cornell/app/views/browse/_heading.html.erb
+++ b/blacklight-cornell/app/views/browse/_heading.html.erb
@@ -46,7 +46,7 @@
             <% if !data["seeAlso"].nil? || !data["notes"].nil?  || data["mainEntry"] == true %>
               <% unless params[:browse_type] == 'Author-Title' %>
 				<% if %>
-                  <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type]+"&headingtype=" + data["headingTypeDesc"], { :class => "info-button btn btn-xs btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => {params[:browse_type]} + ' info for ' +  data["heading"]} do %>
+                  <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type]+"&headingtype=" + data["headingTypeDesc"], { :class => "info-button btn btn-xs btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => params[:browse_type] + ' info for ' + data["heading"]} do %>
                       <%=params[:browse_type]%> info »
                   <% end %>
 				<% end %>

--- a/blacklight-cornell/app/views/browse/_heading.html.erb
+++ b/blacklight-cornell/app/views/browse/_heading.html.erb
@@ -46,13 +46,13 @@
             <% if !data["seeAlso"].nil? || !data["notes"].nil?  || data["mainEntry"] == true %>
               <% unless params[:browse_type] == 'Author-Title' %>
 				<% if %>
-                  <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type]+"&headingtype=" + data["headingTypeDesc"], { :class => "info-button btn btn-sm btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => 'Author info for ' +  data["heading"]} do %>
+                  <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type]+"&headingtype=" + data["headingTypeDesc"], { :class => "info-button btn btn-xs btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => 'Author info for ' +  data["heading"]} do %>
                       <%=params[:browse_type]%> info »
                   <% end %>
 				<% end %>
               <% end %>
               <% if params[:browse_type] == 'Author-Title' %>
-                <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type], { :class => "info-button btn btn-sm btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => 'Author-Title info for ' + data["heading"]} do %>
+                <%= link_to '/browse/info?authq=' + encoded_heading +'&browse_type=' + params[:browse_type], { :class => "info-button btn btn-xs btn-outline-secondary", :onclick => "javascript:_paq.push(['trackEvent', 'browse', 'info-btn']);", 'aria-label' => 'Author-Title info for ' + data["heading"]} do %>
                     <%=params[:browse_type]%> info »
                 <% end %>
               <% end %>

--- a/blacklight-cornell/app/views/catalog/_show_default.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_default.html.erb
@@ -22,7 +22,7 @@
                                        bib: document.id,
                                        browse_type: 'Author',
                                        headingtype: type),
-                      class: 'info-button btn btn-sm btn-outline-secondary',
+                      class: 'info-button btn btn-xs btn-outline-secondary',
                       'aria-label': "Author info for #{search}",
                       role: 'button',
                       onclick: "javascript:_paq.push(['trackEvent', 'itemView', 'author-info']);") %>


### PR DESCRIPTION
- Add aria labels to the info buttons that didn't have them. This is important when we have multiple buttons with the same link label on a single page.
- Change info buttons to a smaller button style
- Add spacing around the Works included values so they are easier to read