### PR TITLE
DACCESS-520 Add message for no results in Articles & Full Text bento box

### DIFF
--- a/blacklight-cornell/app/views/single_search/index.html.erb
+++ b/blacklight-cornell/app/views/single_search/index.html.erb
@@ -233,8 +233,14 @@
                     <%# EBSCO results %>
                     <% @top_4_results.to(0).each do |key, result, position| %>
                       <div id="<%= key+"-Bento2" %>">
-                        <% unless result.nil? or result[0].nil? %>
+                        <% if result.present? && result[0].present? %>
                           <%= render 'single_search/pane_results', :key => key, :result => result %>
+                        <% else %>
+                          <div class="card card-body">
+                            <p>
+                              No results from <%= link_to bento_title(key), bento_all_results_link(key) %>. Try a different search input.
+                            </p>
+                          </div>
                         <% end %>
                       </div>
                     <% end %>


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-520

When 0 results returned for EBSCO EDS bento box (including for /search?q=), add following message:

<img width="875" alt="Screenshot 2025-06-24 at 11 46 33 AM" src="https://github.com/user-attachments/assets/08af673e-6e16-4d9f-9b68-31aa81d93a44" />
