### PR TITLE
Add print styles

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/cul-catalog.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/cul-catalog.scss
@@ -27,7 +27,7 @@
 @import 'virtual-browse';
 @import 'browse-info';
 @import 'knowledge-panel';
-// @import 'print';
+@import 'print';
 
 // Font Awesome
 @import 'font-awesome';

--- a/blacklight-cornell/app/assets/stylesheets/print.scss
+++ b/blacklight-cornell/app/assets/stylesheets/print.scss
@@ -1,0 +1,241 @@
+@media print {
+
+	body {
+		font-family: -apple-system, BlinkMacSystemFont, “Segoe UI”, Roboto, Helvetica, Arial, sans-serif;
+		margin: 0;
+		color: #000;
+		background-color: #fff;
+	}
+
+	// Hide this stuff - TODO: some of these selectors may have been used in BL4, but not needed in BL5
+	.search-home {
+		display: none !important;
+	}
+
+	#skiptocontent,
+	.navbar,
+	.blacklight-nav,
+	.facets,
+	.search-bar,
+	.expand-search,
+	.results-info .dropdown,
+	.results-info .results-count,
+	.help-menu,
+	.modify-search-link,
+
+	.select-all,
+	.select-item,
+	.top-content-title,
+	.return-link,
+	.item-tools,
+	.holdings .btn,
+	.iconcover,
+	.cover,
+	footer,
+	.text-it,
+	.librarian-view,
+	.item-pagination,
+	.clear-bookmarks,
+	#startOverLink,
+	.search-widgets,
+	.pagination,
+    .bookmarks-login,
+
+	.lcs_slide_out,
+	#syndetics_unbound, // TODO: does this actually hide syndetics?
+	.databases-search,
+	.databases-az,
+	.digitalcollections-search .card,
+	.toplink {
+		display: none;
+	}
+
+	// TODO: want to hide these classes but it doesn't work; possibly because it is loaded via js after the print stylesheet is applied
+	// .call-number-browse
+	// .checkbox.select_all
+
+	// Remove Catalog header link
+	.catalog-name {
+		a { text-decoration: none;}
+	}
+
+	// Don't print URLs
+	a[href]:after {
+	    content: ""
+	  }
+	abbr[title]:after {
+	    content: "";
+	  }
+
+	// Print certain URLs
+	// search results: print title and online link 
+	// .blacklight-title_display {
+	// 	a[href]:after {
+	// 	content: " (" attr(href) ")"; }
+	// }
+	// a[href].status-online:after {
+	// 	content: " (" attr(href) ")"; }
+
+	// item view: print url_access_display, url_findingaid_display, url_bookplate_display, url_other_display
+	// a[href].online-access:after,
+	// a[href].url_findingaid_display:after {
+	// 	content: " (" attr(href) ")"; }
+
+	// hides covers on results
+	.document {
+		.iconcover, .bookcover { display: none; } 
+	}
+
+	.blacklight-title_display {
+		margin: .5em 0 0;
+		font-weight: normal;
+		line-height: 1.2em;	}
+	.location { 
+		margin-bottom: 0;
+	}
+
+	// modal
+	.modal {
+		margin-top: 0 !important;
+	}
+	.modal-header button { display: none; }
+	// print  librarian view in monospace font
+	#marc_view { font-family: courier, monospace; }
+	#marc_view .field { clear: both; }
+	#marc_view .tag { 
+		float: left;
+		margin-right: 10px;
+	}
+	#marc_view .ind1,
+	#marc_view .ind2 {
+		margin-right: 10px;
+		width: 20px;
+		display: inline; 
+		float: left;
+	}
+	#marc_view .subfields { 
+		display: inline; 
+		float: left;
+		width: 550px;
+	}
+
+	.print-only { display: block; }
+	#document h2, #document h3 {
+		margin: 0;
+	}
+
+	.availability { 
+		margin: 0;
+		.map-it {
+			display: none;
+		}
+		.holding {
+			.group {
+				font-size: 14px;
+			}
+		}
+		.location {
+			font-size: 13px;
+			margin-bottom: 0;
+		}
+		.worldcat-search {
+			display: none;
+		}
+		.status,
+		.message,
+		.call-number {
+			font-size: 13px;
+			margin-bottom: 0;
+		}
+		.status {
+			margin-top: 0;
+		}
+		.online-link {
+			margin-bottom: 0;
+		}
+	}
+	.availability h3,
+	.availability h4,
+	.availability h5 {
+		margin: 0;
+	}
+	.availability .unstyled {
+		list-style: none;
+		margin: 0 0 .25em;
+		padding: 0;
+	}
+	.availability.well {
+		padding: 0;
+		border: 0;
+	}
+	.item-requests {
+		border-top: 0;
+	}
+
+	//remove underlines from links
+	a { text-decoration: none; }
+
+	// Make online labels visible
+	.label-online {
+		color: black;
+		padding: 0;
+	}
+	// Cut spacing in search results
+	body.catalog-index #documents .document, body.bookmarks-index #documents .document {
+		padding: 0 0 .5em 0;
+	}
+	.document-data .status {
+		margin: 0;
+	}
+	// make search results title smaller
+	.blacklight-title_display {
+		font-size: 14px;
+	}
+	.blacklight-title_uniform_display {
+		font-size: 12px;
+		margin-top: 0;
+	}
+	// tighten up spacing around constraints
+	.selected-facets {
+		padding: 0;
+		.btn {
+			padding: 0 .5em 0 0;
+			border: 0;
+		}
+	}
+	// width of each search result
+	.document-data {
+		width: 100%;
+	}
+	// Hide dropdowns on Selected Items
+	.bookmarks {
+		#per_page-dropdown, #sort-dropdown {
+			display: none;
+		}
+	}
+	// spacing on item view
+	.item-metadata {
+		margin-bottom: 0;
+	}
+	.holding, .holdings-online {
+		padding-top: .5em;
+	}
+	.label-available {
+		padding: 0;
+		color: black;
+		border: 0;
+	}
+	.item-metadata {
+		font-size: 13px;
+	}
+	.access-restriction {
+		margin-top: 0;
+		font-size: 13px;
+	}
+	h2 {
+		font-size: 18px;
+	}
+	.availability h3 {
+		font-size: 18px;
+	}
+}

--- a/blacklight-cornell/app/assets/stylesheets/print.scss
+++ b/blacklight-cornell/app/assets/stylesheets/print.scss
@@ -22,17 +22,12 @@
 	.results-info .results-count,
 	.help-menu,
 	.modify-search-link,
-
-	.select-all,
 	.select-item,
 	.top-content-title,
 	.return-link,
 	.item-tools,
 	.holdings .btn,
-	.iconcover,
-	.cover,
 	footer,
-	.text-it,
 	.librarian-view,
 	.item-pagination,
 	.clear-bookmarks,
@@ -40,19 +35,26 @@
 	.search-widgets,
 	.pagination,
     .bookmarks-login,
-
 	.lcs_slide_out,
 	#syndetics_unbound, // TODO: does this actually hide syndetics?
 	.databases-search,
 	.databases-az,
 	.digitalcollections-search .card,
-	.toplink {
+	.toplink,
+	.facet-pagination{
 		display: none;
 	}
 
 	// TODO: want to hide these classes but it doesn't work; possibly because it is loaded via js after the print stylesheet is applied
 	// .call-number-browse
 	// .checkbox.select_all
+
+	// Hide dropdowns on Selected Items
+	.bookmarks {
+		#per_page-dropdown, #sort-dropdown {
+			display: none;
+		}
+	}
 
 	// Remove Catalog header link
 	.catalog-name {
@@ -67,175 +69,34 @@
 	    content: "";
 	  }
 
-	// Print certain URLs
-	// search results: print title and online link 
-	// .blacklight-title_display {
-	// 	a[href]:after {
-	// 	content: " (" attr(href) ")"; }
-	// }
-	// a[href].status-online:after {
-	// 	content: " (" attr(href) ")"; }
-
-	// item view: print url_access_display, url_findingaid_display, url_bookplate_display, url_other_display
-	// a[href].online-access:after,
-	// a[href].url_findingaid_display:after {
-	// 	content: " (" attr(href) ")"; }
-
 	// hides covers on results
 	.document {
 		.iconcover, .bookcover { display: none; } 
 	}
 
 	.blacklight-title_display {
-		margin: .5em 0 0;
-		font-weight: normal;
-		line-height: 1.2em;	}
-	.location { 
-		margin-bottom: 0;
+		margin: 1rem 0 0;
 	}
 
-	// modal
-	.modal {
-		margin-top: 0 !important;
-	}
-	.modal-header button { display: none; }
+	// .modal-header button { display: none; } // TODO: not needed?
+
 	// print  librarian view in monospace font
 	#marc_view { font-family: courier, monospace; }
-	#marc_view .field { clear: both; }
-	#marc_view .tag { 
-		float: left;
-		margin-right: 10px;
-	}
-	#marc_view .ind1,
-	#marc_view .ind2 {
-		margin-right: 10px;
-		width: 20px;
-		display: inline; 
-		float: left;
-	}
-	#marc_view .subfields { 
-		display: inline; 
-		float: left;
-		width: 550px;
-	}
 
-	.print-only { display: block; }
-	#document h2, #document h3 {
-		margin: 0;
-	}
-
-	.availability { 
-		margin: 0;
-		.map-it {
-			display: none;
-		}
-		.holding {
-			.group {
-				font-size: 14px;
-			}
-		}
-		.location {
-			font-size: 13px;
-			margin-bottom: 0;
-		}
-		.worldcat-search {
-			display: none;
-		}
-		.status,
-		.message,
-		.call-number {
-			font-size: 13px;
-			margin-bottom: 0;
-		}
-		.status {
-			margin-top: 0;
-		}
-		.online-link {
-			margin-bottom: 0;
-		}
-	}
-	.availability h3,
-	.availability h4,
-	.availability h5 {
-		margin: 0;
-	}
-	.availability .unstyled {
-		list-style: none;
-		margin: 0 0 .25em;
-		padding: 0;
-	}
-	.availability.well {
-		padding: 0;
-		border: 0;
-	}
+	// remove border above request buttons (which we do not display in print)
 	.item-requests {
 		border-top: 0;
 	}
 
-	//remove underlines from links
-	a { text-decoration: none; }
-
-	// Make online labels visible
-	.label-online {
-		color: black;
-		padding: 0;
-	}
 	// Cut spacing in search results
 	body.catalog-index #documents .document, body.bookmarks-index #documents .document {
 		padding: 0 0 .5em 0;
 	}
-	.document-data .status {
-		margin: 0;
-	}
-	// make search results title smaller
-	.blacklight-title_display {
-		font-size: 14px;
-	}
-	.blacklight-title_uniform_display {
-		font-size: 12px;
-		margin-top: 0;
-	}
-	// tighten up spacing around constraints
-	.selected-facets {
-		padding: 0;
-		.btn {
-			padding: 0 .5em 0 0;
-			border: 0;
-		}
-	}
-	// width of each search result
-	.document-data {
-		width: 100%;
-	}
-	// Hide dropdowns on Selected Items
-	.bookmarks {
-		#per_page-dropdown, #sort-dropdown {
-			display: none;
-		}
-	}
-	// spacing on item view
-	.item-metadata {
-		margin-bottom: 0;
-	}
-	.holding, .holdings-online {
-		padding-top: .5em;
-	}
-	.label-available {
-		padding: 0;
+
+	// make badges readable
+	.badge {
+		background: white;
 		color: black;
 		border: 0;
-	}
-	.item-metadata {
-		font-size: 13px;
-	}
-	.access-restriction {
-		margin-top: 0;
-		font-size: 13px;
-	}
-	h2 {
-		font-size: 18px;
-	}
-	.availability h3 {
-		font-size: 18px;
 	}
 }


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-309

We (I) removed the print stylesheet in 2019; I'm not sure why. It might have gotten unwieldy; it might have needed a bunch of clean-up after a Blacklight upgrade. Regardless, I'm bringing it back. It does make the print output more concise and should be unnoticed by most users (hopefully).

I cleaned out a lot of old styles which were either no longer in use or unnecessary.