### PR TITLE
DACCESS-309: hide navbar-toggler from print

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/print.scss
+++ b/blacklight-cornell/app/assets/stylesheets/print.scss
@@ -41,7 +41,8 @@
 	.databases-az,
 	.digitalcollections-search .card,
 	.toplink,
-	.facet-pagination{
+	.facet-pagination,
+	.navbar-toggler {
 		display: none;
 	}
 


### PR DESCRIPTION
A small empty box was included in print output, this was the mobile nav button for the util links. Removed it from print display.