### PR TITLE
DACCESS-576 Finding aids will direct to the Aspace PUI

### DIFF
--- a/blacklight-cornell/app/helpers/cornell_catalog_helper.rb
+++ b/blacklight-cornell/app/helpers/cornell_catalog_helper.rb
@@ -211,10 +211,7 @@ module CornellCatalogHelper
 	return nil unless document['marc_display'] && ENV['AEON_PUI_REQUEST'].present?
 
 	# return nil if CULAspaceURI is not found in the marc 035 field
-	culaspace_uri_value = document['marc_display']
-		.scan(/<datafield tag="035".*?>.*?<subfield code="a">(.*?)<\/subfield>/m)
-		.flatten
-		.find { |value| value.include?('CULAspaceURI') }
+	culaspace_uri_value = Nokogiri::XML(document['marc_display']).at_css('datafield[tag="035"] subfield[code="a"]:contains("CULAspaceURI")')&.text
 	return nil unless culaspace_uri_value
 
 	# return nil if the repo ID and resource ID do not exist

--- a/blacklight-cornell/app/helpers/cornell_catalog_helper.rb
+++ b/blacklight-cornell/app/helpers/cornell_catalog_helper.rb
@@ -211,7 +211,8 @@ module CornellCatalogHelper
 	return nil unless document['marc_display'] && ENV['AEON_PUI_REQUEST'].present?
 
 	# return nil if CULAspaceURI is not found in the marc 035 field
-	culaspace_uri_value = Nokogiri::XML(document['marc_display']).at_css('datafield[tag="035"] subfield[code="a"]:contains("CULAspaceURI")')&.text
+	culaspace_uri_value = Nokogiri::XML(document['marc_display'])
+	  .at_css('datafield[tag="035"] subfield[code="a"]:contains("CULAspaceURI")')&.text
 	return nil unless culaspace_uri_value
 
 	# return nil if the repo ID and resource ID do not exist

--- a/blacklight-cornell/app/helpers/cornell_catalog_helper.rb
+++ b/blacklight-cornell/app/helpers/cornell_catalog_helper.rb
@@ -198,6 +198,33 @@ module CornellCatalogHelper
 	LOC_CODES[code]
 	end
 
+  # returns the PUI Aspace url if resource id and repo id exist in the marc 035 field
+  # (CULAspaceURI) in the marc 035 field must have:
+  #   - resource id: is the value after /resources/
+  #   - repo id: is the value after /repositories/
+  #
+  # @param [Hash] document - metadata for the item
+  #
+  # @return [string] url or nil
+  def aspace_pui_url(document)
+	# return early if marc fields and environment variable are not present
+	return nil unless document['marc_display'] && ENV['AEON_PUI_REQUEST'].present?
+
+	# return nil if CULAspaceURI is not found in the marc 035 field
+	culaspace_uri_value = document['marc_display']
+		.scan(/<datafield tag="035".*?>.*?<subfield code="a">(.*?)<\/subfield>/m)
+		.flatten
+		.find { |value| value.include?('CULAspaceURI') }
+	return nil unless culaspace_uri_value
+
+	# return nil if the repo ID and resource ID do not exist
+	match = culaspace_uri_value.match(/\(CULAspaceURI\)\/repositories\/(\d+)\/resources\/(\d+)/)
+	return nil unless match && match[1].present? && match[2].present?
+
+	# Construct and return the finding aid link
+	"#{ENV['AEON_PUI_REQUEST']}#{culaspace_uri_value.gsub('(CULAspaceURI)', '')}"
+  end
+
   # Generates the target url
   #
   # @param [String] group - "Circulating" or "AEON_SCAN_REQUEST"

--- a/blacklight-cornell/app/views/catalog/_request_buttons.html.erb
+++ b/blacklight-cornell/app/views/catalog/_request_buttons.html.erb
@@ -22,7 +22,7 @@
     <% elsif counter.blank? %>
       <%#= link_to "Request item#{reading}", request_context_path, { :title => 'Request', :class => 'btn btn-danger', :id => 'id_request' }   Delete this? Or keep around for post-covid?%>
       <% if !@document['etas_facet'].present? %>
-          <% if !@document["location"].nil? %>
+          <% if !@document["location"].nil? && aspace_pui_url(@document).nil? %>
             <% if reserve_only %>
               <%= link_to "Request item#{reading}", "#", { :title => 'Request', :class => 'btn btn-danger disabled', :id => 'id_request', :tabindex => '-1', :aria_disabled => 'true', :style => 'pointer-events: none;' } %>
             <% else %>
@@ -36,7 +36,7 @@
     <% else %>
       <%#= link_to "Request item#{reading}", request_context_path, { :title => 'Request', :class => 'btn btn-danger', 'data-counter'.to_sym => counter, :id => 'id_request' } Delete this?%>
        <% if !@document['etas_facet'].present? %>
-          <% if !@document["location"].nil? %>
+          <% if !@document["location"].nil? && aspace_pui_url(@document).nil? %>
             <% if reserve_only %>
               <%= link_to "Request item#{reading}", "#", { :title => 'Request', :class => 'btn btn-danger disabled', :id => 'id_request', :tabindex => '-1', :aria_disabled => 'true', :style => 'pointer-events: none;' } %>
             <% else %>

--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -42,18 +42,31 @@
 	      Availability
 	    </div>
 	    <div class="card-block">
-	      <%# check the document rather than the finding_aid() method %>
-	      <% if @document['url_findingaid_display'].present? %>
-					<% url_findingaid_displays = render_display_link :document => @document, :field => 'url_findingaid_display', :format => 'default' %>
-					<div class="url_findingaid_display" id="finding_aid">
-						<% url_findingaid_displays.each do |url_findingaid_display| %>
-							<div class="url_findingaid_link">
-								<i class="fa fa-check" aria-hidden="true"></i>
-								<%= url_findingaid_display %>
-							</div>
-						<% end %>
+			<%# Determine if the request should be made through the catalog or the Aspace PUI %>
+			<% url = aspace_pui_url(@document) %>
+			<% if url.present? %>
+				<%# Item is in Aspace so render finding aids to direct to the PUI %>
+				<% url_findingaid_displays = render_display_link :value => [url], :field => 'url_findingaid_display', :format => 'default' %>
+				<div class="url_findingaid_display" id="finding_aid">
+					<% url_findingaid_displays.each do |url_findingaid_display| %>
+					<div class="url_findingaid_link">
+						<i class="fa fa-check" aria-hidden="true"></i>
+						<%= url_findingaid_display %>
 					</div>
-	      <% end %>
+					<% end %>
+				</div>
+			<% elsif @document['url_findingaid_display'].present? %>
+				<%# Item is not in Aspace so render finding aids from the document %>
+				<% url_findingaid_displays = render_display_link :document => @document, :field => 'url_findingaid_display', :format => 'default' %>
+				<div class="url_findingaid_display" id="finding_aid">
+					<% url_findingaid_displays.each do |url_findingaid_display| %>
+					<div class="url_findingaid_link">
+						<i class="fa fa-check" aria-hidden="true"></i>
+						<%= url_findingaid_display %>
+					</div>
+					<% end %>
+				</div>
+			<% end %>
 
 	      <%  summary_holdings = '' %>
 	      <% if is_online?(@document) %>

--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -47,17 +47,11 @@
 			<% if url.present? %>
 				<%# Item is in Aspace so render finding aids to direct to the PUI %>
 				<% url_findingaid_displays = render_display_link :value => [url], :field => 'url_findingaid_display', :format => 'default' %>
-				<div class="url_findingaid_display" id="finding_aid">
-					<% url_findingaid_displays.each do |url_findingaid_display| %>
-					<div class="url_findingaid_link">
-						<i class="fa fa-check" aria-hidden="true"></i>
-						<%= url_findingaid_display %>
-					</div>
-					<% end %>
-				</div>
 			<% elsif @document['url_findingaid_display'].present? %>
 				<%# Item is not in Aspace so render finding aids from the document %>
 				<% url_findingaid_displays = render_display_link :document => @document, :field => 'url_findingaid_display', :format => 'default' %>
+			<% end %>
+			<% if url_findingaid_displays.present? %>
 				<div class="url_findingaid_display" id="finding_aid">
 					<% url_findingaid_displays.each do |url_findingaid_display| %>
 					<div class="url_findingaid_link">

--- a/blacklight-cornell/spec/helpers/cornell_catalog_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/cornell_catalog_helper_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe CornellCatalogHelper, type: :helper do
+  describe '#aspace_pui_url' do
+    let(:document_with_aspace) do
+      {
+        'marc_display' => <<-XML
+          <record>
+            <datafield tag="035">
+              <subfield code="a">(CULAspace)11111</subfield>
+            </datafield>
+            <datafield tag="035">
+              <subfield code="a">(CULAspaceURI)/repositories/2/resources/2345</subfield>
+            </datafield>
+            <datafield tag="035">
+              <subfield code="a">(OCoLC)0000000001</subfield>
+            </datafield>
+          </record>
+        XML
+      }
+    end
+
+    let(:document_with_missing_repoid) do
+      {
+        'marc_display' => <<-XML
+          <record>
+            <datafield tag="035">
+              <subfield code="a">(CULAspaceURI)/repositories//resources/2345</subfield>
+            </datafield>
+          </record>
+        XML
+      }
+    end
+
+    let(:document_with_missing_itemid) do
+      {
+        'marc_display' => <<-XML
+          <record>
+            <datafield tag="035">
+              <subfield code="a">(CULAspaceURI)/repositories/2/resources/</subfield>
+            </datafield>
+          </record>
+        XML
+      }
+    end
+
+    let(:document_with_invalid_aspace_format) do
+      {
+        'marc_display' => <<-XML
+          <record>
+            <datafield tag="035">
+              <subfield code="a">(CULAspaceURI)24234234234234</subfield>
+            </datafield>
+          </record>
+        XML
+      }
+    end
+
+    let(:document_without_aspace_value) do
+      {
+        'marc_display' => <<-XML
+          <record>
+            <datafield tag="035">
+              <subfield code="a">(CStRLIN)222222</subfield>
+            </datafield>
+            <datafield tag="035">
+              <subfield code="a">(OCoLC)0000000002</subfield>
+            </datafield>
+          </record>
+        XML
+      }
+    end
+
+    context 'when the environment var AEON_PUI_REQUEST is present' do
+        before do
+          allow(ENV).to receive(:[]).with('AEON_PUI_REQUEST').and_return('http://example.com')
+        end
+        
+        it 'returns link if the document contains a valide CULAspaceURI value' do
+          expect(helper.aspace_pui_url(document_with_aspace)).to eq("http://example.com/repositories/2/resources/2345")
+        end
+    
+        it 'returns nil if the document does not contain a CULAspaceURI value' do
+          expect(helper.aspace_pui_url(document_without_aspace_value)).to be nil
+        end
+
+        it 'returns nil if the CULAspaceURI value is missing the repoid' do
+          expect(helper.aspace_pui_url(document_with_missing_repoid)).to be nil
+        end
+
+        it 'returns nil if the CULAspaceURI value is missing the itemid' do
+          expect(helper.aspace_pui_url(document_with_missing_itemid)).to be nil
+        end
+
+        it 'returns nil if the CULAspaceURI value is invalid format' do
+          expect(helper.aspace_pui_url(document_with_invalid_aspace_format)).to be nil
+        end
+    end
+
+    context 'when the environment var AEON_PUI_REQUEST is NOT present' do
+        before do
+          allow(ENV).to receive(:[]).with('AEON_PUI_REQUEST').and_return(nil)
+        end
+        
+        it 'returns nil regardless of the marc 035 field value' do
+          expect(helper.aspace_pui_url(document_with_aspace)).to be nil
+          expect(helper.aspace_pui_url(document_without_aspace_value)).to be nil
+        end
+    end
+
+    it 'returns nil if the document does not have a marc_display field' do
+      expect(helper.aspace_pui_url({})).to be nil
+    end
+  end
+end


### PR DESCRIPTION
Finding aids will direct to the Aspace PUI if the marc 035 field value contains the url. 
`(035    ‡a (CULAspaceURI)/repositories/2/resources/1635)`

The reading room and scan request buttons will also be hidden when the url exists

AEON_PUI_REQUEST environment variable is introduced `'https://archives.library.cornell.edu'`