### PR TITLE
DACCESS-514 Fix issues with author lookups in Endnote XML and RIS exports

### DIFF
--- a/blacklight-cornell/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/blacklight-cornell/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -280,7 +280,7 @@ module Blacklight::Solr::Document::MarcExport
   def get_all_authors(record)
     Rails.logger.debug("es287_debug **** #{__FILE__} #{__LINE__} #{__method__}")
     translator_code = "trl"; editor_code = "edt"; compiler_code = "com"; author_code = "aut"
-    translator_code << "translator"; editor_code << "editor"; compiler_code << "compiler"; author_code = "author"
+    translator_code << "translator"; editor_code << "editor"; compiler_code << "compiler"; author_code << "author"
     primary_authors = []; translators = []; editors = []; compilers = []
     meeting_authors = []; secondary_authors = []
     primary_corporate_authors = []; secondary_corporate_authors = [];

--- a/blacklight-cornell/lib/blacklight/solr/document/ris.rb
+++ b/blacklight-cornell/lib/blacklight/solr/document/ris.rb
@@ -65,12 +65,12 @@ FACET_TO_RIS_TYPE =  { "ABST"=>"ABST", "ADVS"=>"ADVS", "AGGR"=>"AGGR",
     # each one is an array. Oddly, though, RIS format doesn't seem to provide
     # for anything except 'author'
     primary_authors = authors[:primary_authors]
-    corp_authors = authors[:corporate_authors]
+    corp_authors = authors[:primary_corporate_authors] + authors[:secondary_corporate_authors]
     editors = authors[:editors]
     if !primary_authors.empty?
       output += "AU  - #{primary_authors[0]}\n"
       if primary_authors.length > 1
-        for i in 1..primary_authors.length
+        for i in 1..(primary_authors.length - 1)
           output += "A#{i}  - #{primary_authors[i]}\n"
         end
       end
@@ -79,7 +79,7 @@ FACET_TO_RIS_TYPE =  { "ABST"=>"ABST", "ADVS"=>"ADVS", "AGGR"=>"AGGR",
     if !corp_authors.empty? && editors.empty?
       output += "AU  - #{corp_authors[0]}\n"
       if corp_authors.length > 1
-        for i in 1..corp_authors.length
+        for i in 1..(corp_authors.length - 1)
           output += "A#{i}  - #{corp_authors[i]}\n"
         end
       end


### PR DESCRIPTION
When a record includes a corporate name (110 or 710 field), a 500 error is returned when trying to use the Endnote XML or RIS export options. The root cause is an issue with the `get_all_authors` method in blacklight-cornell/app/models/concerns/blacklight/solr/document/marc_export.rb. My solution is to remove the more general `corporate_authors` list, which is causing the error, and instead use the preexisting `primary_corporate_authors` and `secondary_corporate_authors` lists, which are working as expected. This reduces complexity and mirrors more closely how the non-corporate authors are handled.

I also did some other minor fixes and cleanup of the author fields, including: 
- adding an author relator code lookup within the secondary authors list and moving those values to the primary authors list (a 700 field author is in fact a primary author - see https://www.loc.gov/marc/relators/relaterm.html)
- adding punctuation cleanup to subfield b of the primary and secondary corporate names
- deduping values between the primary and secondary corporate names
- removing an empty author field generated in `export_ris` when there are multiple values