### PR TITLE
DACCESS-601 Update Articles & Full Text view more link and related code

### DIFF
--- a/blacklight-cornell/app/helpers/single_search_helper.rb
+++ b/blacklight-cornell/app/helpers/single_search_helper.rb
@@ -15,6 +15,7 @@ module SingleSearchHelper
     tr(" -", "_").
     downcase
   end
+  
   def ss_uri_encode (link_url)
     link_url = link_url.gsub('% ','%25%20') unless link_url.match('%25')
     link_url = link_url.gsub('$','%24')
@@ -30,7 +31,7 @@ module SingleSearchHelper
   end
 
   def is_catalog_pane?(pane)
-    if pane == 'Articles & Full Text' || pane == 'Library Guides' || pane == 'Digital Collections' || pane == 'Repositories'
+    if pane == 'Articles & Full Text' || pane == 'Research Guides' || pane == 'Digital Collections' || pane == 'Repositories'
       false
     else
        true
@@ -59,20 +60,6 @@ module SingleSearchHelper
     end
 
     link_url = ss_uri_encode(link)
-  end
-
-  def bento_eds_count()
-    eds_total = 0
-    bq = params[:q] || params[:query]
-    if bq.present?
-      searcher = BentoSearch::ConcurrentSearcher.new(:ebsco_eds)
-      searcher.search(bq, :per_page => 0)
-      searcher.results.each_pair do |key, result|
-        eds_total = result.total_items.to_s
-        break
-      end
-    end
-    return eds_total
   end
 
   def bento_title(key)

--- a/blacklight-cornell/app/helpers/single_search_helper.rb
+++ b/blacklight-cornell/app/helpers/single_search_helper.rb
@@ -30,12 +30,8 @@ module SingleSearchHelper
     link_url = link_url.gsub(')','%29')
   end
 
-  def is_catalog_pane?(pane)
-    if pane == 'Articles & Full Text' || pane == 'Research Guides' || pane == 'Digital Collections' || pane == 'Repositories'
-      false
-    else
-       true
-    end
+  def is_catalog_pane?(key)
+    ['ebsco_eds', 'libguides', 'digitalCollections', 'institutionalRepositories'].exclude?(key)
   end
 
   def bento_all_results_link(key)

--- a/blacklight-cornell/app/views/single_search/_pane_results.html.erb
+++ b/blacklight-cornell/app/views/single_search/_pane_results.html.erb
@@ -38,7 +38,7 @@
           <i class="fa fa-angle-double-right"></i>
         <% end %>
       <% end %>
-      <% if is_catalog_pane?(bento_title(key)) == true %>
+      <% if is_catalog_pane?(key) == true %>
         <div class="bento_pane_advanced">
           <% qp2 = "f%5Bformat%5D%5B%5D=#{bento_blacklight_format(key)}&op_row%5B%5D=AND&q_row%5B%5D=#{ss_uri_encode(params[:q]).gsub('&','%26')}&search_field_row%5B%5D=all_fields" %>
           or use <%= link_to 'advanced search',"edit?#{qp2}", {:onclick => "javascript:_paq.push(['trackEvent', 'advancedLink', '#{bento_blacklight_format(key)}'])"}  %>

--- a/blacklight-cornell/app/views/single_search/_pane_results.html.erb
+++ b/blacklight-cornell/app/views/single_search/_pane_results.html.erb
@@ -17,28 +17,22 @@
     <div class="view-all">
       <% if key == "libguides" %>
         <%= link_to 'View All Research Guides', link_url, :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', 'LibGuides'])", :id => "link_top_libguides" %>
-      <% else %>
+      <% elsif !result.nil? %>
         <%= link_to link_url, class: "btn btn-outline-secondary btn-sm", onclick: "javascript:_paq.push(['trackEvent', 'allResultsLink', '#{bento_blacklight_format(key) || bento_title(key)}'])", id: "link_top_" + downcast(key) do %>
           View
           <% if key == "ebsco_eds" %>
             results from
             <%= bento_title(key) %>
-          <% else %> 
-            <%= number_with_delimiter(result.total_items) %>
-            <% if !result.nil? %>
-              <% if key == "digitalCollections" || key == "institutionalRepositories" %>
-                <%= bento_title(key) %>
-                Item<%= result.total_items > 1 ? 's' : '' %>
-              <% else %>  
-                <%= result.total_items > 1 ? bento_title(key) : bento_blacklight_format(key) %>
-                from Catalog
-              <% end %>
-            <% end %>
-          <% end %>  
+          <% elsif key == "digitalCollections" || key == "institutionalRepositories" %>  
+            <%= pluralize(number_with_delimiter(result.total_items), (bento_title(key) + ' Item')) %>
+          <% else %>
+            <%= pluralize(number_with_delimiter(result.total_items), bento_blacklight_format(key), plural: bento_title(key)) %>
+            from Catalog
+          <% end %> 
           <i class="fa fa-angle-double-right"></i>
         <% end %>
       <% end %>
-      <% if is_catalog_pane?(key) == true %>
+      <% if is_catalog_pane?(key) %>
         <div class="bento_pane_advanced">
           <% qp2 = "f%5Bformat%5D%5B%5D=#{bento_blacklight_format(key)}&op_row%5B%5D=AND&q_row%5B%5D=#{ss_uri_encode(params[:q]).gsub('&','%26')}&search_field_row%5B%5D=all_fields" %>
           or use <%= link_to 'advanced search',"edit?#{qp2}", {:onclick => "javascript:_paq.push(['trackEvent', 'advancedLink', '#{bento_blacklight_format(key)}'])"}  %>

--- a/blacklight-cornell/app/views/single_search/_pane_results.html.erb
+++ b/blacklight-cornell/app/views/single_search/_pane_results.html.erb
@@ -16,61 +16,33 @@
     <%= bento_search result  %>
     <div class="view-all">
       <% if key == "libguides" %>
-        <%= link_to 'View All Research Guides', 'http://guides.library.cornell.edu/libguides/home', :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', 'LibGuides'])", :id => "link_top_libguides" %>
-      <% elsif key == "ebsco_eds" %>
-        <%= link_to link_url, :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', 'Articles & Full Text'])" do %>
+        <%= link_to 'View All Research Guides', link_url, :class => "btn btn-outline-secondary btn-sm", :onclick => "javascript:_paq.push(['trackEvent', 'allResultsLink', 'LibGuides'])", :id => "link_top_libguides" %>
+      <% else %>
+        <%= link_to link_url, class: "btn btn-outline-secondary btn-sm", onclick: "javascript:_paq.push(['trackEvent', 'allResultsLink', '#{bento_blacklight_format(key) || bento_title(key)}'])", id: "link_top_" + downcast(key) do %>
           View
-          <%= number_with_delimiter(result.total_items) %>
-          <%= bento_title(key) %>
+          <% if key == "ebsco_eds" %>
+            results from
+            <%= bento_title(key) %>
+          <% else %> 
+            <%= number_with_delimiter(result.total_items) %>
+            <% if !result.nil? %>
+              <% if key == "digitalCollections" || key == "institutionalRepositories" %>
+                <%= bento_title(key) %>
+                Item<%= result.total_items > 1 ? 's' : '' %>
+              <% else %>  
+                <%= result.total_items > 1 ? bento_title(key) : bento_blacklight_format(key) %>
+                from Catalog
+              <% end %>
+            <% end %>
+          <% end %>  
           <i class="fa fa-angle-double-right"></i>
         <% end %>
-      <% else %>
-      <%= link_to link_url, class: "btn btn-outline-secondary btn-sm", onclick: "javascript:_paq.push(['trackEvent', 'allResultsLink', '#{bento_blacklight_format(key) || bento_title(key)}'])", id: "link_top_" + downcast(key) do %>
-        View
-        <!-- = '(r%2.3f)' % (@scores[key].nil? ? 0 : @scores[key])
-        -->
-        <%= number_with_delimiter(result.total_items) %>
-        <% if !result.nil? %>
-          <% if result.total_items && result.total_items > 1 %>
-            <%= bento_title(key) %>
-          <% end %>
-        <% else %>
-          <% if ['Theses', 'Miscellaneous', 'Manuscripts/Archives'].exclude?(bento_title(key)) %>
-            <%= bento_title(key)[0...-1] %>
-          <% end %>
-          <% if bento_title(key) == "Theses" %>
-            Thesis
-          <% end %>
-          <% if bento_title(key) == "Miscellaneous" %>
-            Miscellaneous
-          <% end %>
-          <% if bento_title(key) == "Manuscripts/Archives" %>
-            Manuscript/Archive
-          <% end %>
-        <% end %>
-        <% bento_title(key) %>
-        <% if bento_title(key) == 'Articles & Full Text' %>
-        <% elsif bento_title(key) == 'Library Guides' %>
-            Research Guides
-        <% elsif bento_title(key) == 'Digital Collections' %>
-            Items
-        <% elsif bento_title(key) == 'Repositories' %>
-            Item<%= result.total_items > 1 ? 's' : '' %>
-        <% else %>
-          from Catalog
-
-        <% end %>
-        <i class="fa fa-angle-double-right"></i>
       <% end %>
-      <% if is_catalog_pane?(bento_title(key)) == true%>
+      <% if is_catalog_pane?(bento_title(key)) == true %>
         <div class="bento_pane_advanced">
           <% qp2 = "f%5Bformat%5D%5B%5D=#{bento_blacklight_format(key)}&op_row%5B%5D=AND&q_row%5B%5D=#{ss_uri_encode(params[:q]).gsub('&','%26')}&search_field_row%5B%5D=all_fields" %>
           or use <%= link_to 'advanced search',"edit?#{qp2}", {:onclick => "javascript:_paq.push(['trackEvent', 'advancedLink', '#{bento_blacklight_format(key)}'])"}  %>
         </div>
       <% end %>
-    <% end %>
-
-
-
     </div>
 <% end %>

--- a/blacklight-cornell/app/views/single_search/index.html.erb
+++ b/blacklight-cornell/app/views/single_search/index.html.erb
@@ -103,7 +103,7 @@
                           <li>
                             <i class="fa fa-<%= formats_icon_mapping(bento_title(key)) %>"></i>
                             <% link_url = bento_all_results_link(key) %>
-                            <%= link_to link_url ,:id => "facet_link_" + downcast(key), :onclick => "javascript:_paq.push(['trackEvent', 'sidebarLink', '#{bento_blacklight_format(key)}'])", :class => "facet_link_" + downcast(key) do %>
+                            <%= link_to link_url ,:id => "facet_link_" + downcast(key), :onclick => "javascript:_paq.push(['trackEvent', 'sidebarLink', '#{bento_blacklight_format(key) || bento_title(key)}'])", :class => "facet_link_" + downcast(key) do %>
                               <%= bento_title(key) %>
                               <!-- ='(r%2.3f)' % (@scores[key].nil? ? 0 : @scores[key])
                               -->


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-601

I updated “View # Articles & Full Text” link in bento box to "View results from Articles & Full Text." In the process, I did some clean-up of the related view and helpers, including: 

- Removing the unused helper method `bento_eds_count()`
- Simplifying the conditional logic for the different engine types in the view `blacklight-cornell/app/helpers/single_search_helper.rb`
- For catalog items, using `bento_blacklight_format()` as a part of the link text when there is only one item rather incomplete hard-coded logic in the view (this is consistently used for the singular labeling of catalog format types)
- fixing issue with event tracking of Digital Collections and Repositories in "see more" side panel (matching logic used in `blacklight-cornell/app/views/single_search/index.html.erb` with `blacklight-cornell/app/views/single_search/_pane_results.html.erb`)


<img width="1250" height="681" alt="Screenshot 2025-08-14 at 1 46 01 PM" src="https://github.com/user-attachments/assets/3f84fc1f-07b6-48dd-8cb2-715922978db3" />
