### PR TITLE
DACCESS-633 Remove unused citation and refworks export code

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_bookmarks.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_bookmarks.scss
@@ -5,17 +5,12 @@
 	.item-tools {
 		margin-top: .5em;
 	}
-}	
+}
+	
 .clear-bookmarks {
 	margin-left: 1em;
 }
 
-
-.bookmarks-refworks input.submit {display:none;}
-
-// Wanted to extend Bootstrap's default like this:
-// .bookmarks-refworks a { @extend .dropdown-menu > li > form > a; }
-// -- but you can't extend nested selectors :(
 .dropdown-menu {
 	> li > form > a {
 		display: block;

--- a/blacklight-cornell/app/helpers/display_helper.rb
+++ b/blacklight-cornell/app/helpers/display_helper.rb
@@ -974,7 +974,7 @@ end
 
   def is_exportable document
     if document.present? && document.export_formats.present?
-      if document.export_formats.keys.include?(:refworks_marc_txt) || document.export_formats.keys.include?(:endnote)
+      if document.export_formats.keys.include?(:ris) || document.export_formats.keys.include?(:endnote)
         return true
       end
     end

--- a/blacklight-cornell/app/views/catalog/_refworks_form.html.erb
+++ b/blacklight-cornell/app/views/catalog/_refworks_form.html.erb
@@ -1,7 +1,0 @@
-<%= form_tag "http://www.refworks.com/express/expressimport.asp?vendor=#{application_name}&filter=MARC%20Format&encoding=65001", :name => "refworks", :target => "_blank", :id => "refworks-form" do %>
-
-<%= hidden_field_tag "ImportData", render_refworks_texts(documents) %>
-<%= submit_tag t('blacklight.tools.refworks'), :class => 'submit'%>
-<%= link_to_function t('blacklight.tools.refworks'), "document.refworks.submit();" %>
-<% end %>
-

--- a/blacklight-cornell/config/locales/blacklight.en.yml
+++ b/blacklight-cornell/config/locales/blacklight.en.yml
@@ -122,10 +122,8 @@ en:
 
     tools:
       title: 'Tools'
-      cite: 'Cite'
       endnote: 'EndNote'
       endnote_xml: 'EndNote XML'
-      refworks: 'Refworks'
       mendeley: 'RIS'
       zotero: 'Zotero'
       email: 'Email'

--- a/blacklight-cornell/spec/models/marc_solr_document_spec.rb
+++ b/blacklight-cornell/spec/models/marc_solr_document_spec.rb
@@ -99,11 +99,6 @@ describe Blacklight::Solr::Document::MarcExport do
   before(:all) do
     @book_recs = {}
     # descriptive strings from the csl files.
-    @apa_match_style = "American Psychological Association 6th edition"
-    @cse_match_style = "The Council of Science Editors style 8th edition, Citation-Sequence system: numbers in text, sorted by order of appearance in text."
-    @chicago_match_style = "Chicago format with full notes and bibliography"
-    @mla_match_style = "This style adheres to the MLA 7th edition handbook and contains modifications to these types of sources: e-mail, forum posts, interviews, manuscripts, maps, presentations, TV broadcasts, and web pages."
-    @mla8_match_style = "This style adheres to the MLA 8th edition handbook. Follows the structure of references as outlined in the MLA Manual closely"
     dclass = MockMarcDocument
     dclass.use_extension(Blacklight::Solr::Document::Endnote)
     ids = ["1001", "1002", "393971", "1378974", "1676023", "2083900", "3261564", "3902220",
@@ -193,23 +188,6 @@ describe Blacklight::Solr::Document::MarcExport do
   describe "export_as_xml" do
     it "should export marcxml as xml" do
       expect(marc_from_xml(@typical_record.export_as_xml)).to eq(marc_from_xml(@typical_record.export_as_marcxml))
-    end
-  end
-
-  describe "export_as_refworks_marc_txt" do
-    it "should export correctly" do
-      expect(@music_record.export_as_refworks_marc_txt).to match("LEADER 01828cjm a2200409 a 4500001    a4768316\n003    SIRSI\n007    sd fungnnmmned\n008    020117p20011990xxuzz    h              d\n245 00 Music for horn |h[sound recording] / |cBrahms, Beethoven, von Krufft.\n260    [United States] : |bHarmonia Mundi USA, |cp2001.\n700 1  Greer, Lowell.\n700 1  Lubin, Steven.\n700 1  Chase, Stephanie, |d1957-\n700 12 Brahms, Johannes, |d1833-1897. |tTrios, |mpiano, violin, horn, |nop. 40, |rE? major.\n700 12 Beethoven, Ludwig van, |d1770-1827. |tSonatas, |mhorn, piano, |nop. 17, |rF major.\n700 12 Krufft, Nikolaus von, |d1779-1818. |tSonata, |mhorn, piano, |rF major.\n")
-    end
-
-    describe "for UTF-8 record" do
-      it "should export in Unicode normalized C form" do
-        @utf8_exported = @record_utf8_decomposed.export_as_refworks_marc_txt
-
-        if defined? Unicode
-          expect(@utf8_exported).not_to include("\314\204\312\273") # decomposed
-          expect(@utf8_exported).to include("\304\253\312\273") # C-form normalized
-        end
-      end
     end
   end
 


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-633

The Citation and Refworks export features are no longer used, but a lot of the code is still hanging around. This removes that code from `blacklight-cornell/app/models/concerns/blacklight/solr/document/marc_export.rb` as well as related views, helpers, and specs.