### PR TITLE
DACCESS-624 - Set advanced search form facets from url params, not input vals

### DIFF
--- a/blacklight-cornell/app/assets/javascripts/search_form.js
+++ b/blacklight-cornell/app/assets/javascripts/search_form.js
@@ -1,16 +1,13 @@
 document.addEventListener("DOMContentLoaded", function () {
     const advancedSearchLink = document.getElementById("advanced-search-link");
-    // Select all inputs, selects, and textareas if no dynamic fields are found
-    let formFields = document.querySelectorAll("[data-dynamic='true']");
-    if (formFields.length === 0) {
-        formFields = document.querySelectorAll("input, select, textarea");
-    }
+    // Select simple search and browse form fields
+    let formFields = document.querySelectorAll("input#q, select#search_field, input#authq, select#browse_type");
 
     if (advancedSearchLink && formFields) {
         const searchField = document.getElementById("q");
         // Update the Advanced Search link dynamically
         const updateAdvancedSearchLink = () => {
-            let params = new URLSearchParams();
+            let advancedSearchLinkParams = new URLSearchParams(advancedSearchLink.href.split("?")[1]);
             let hasSearchText = searchField && searchField.value.trim().length > 0;
 
             formFields.forEach((field) => {
@@ -22,16 +19,15 @@ document.addEventListener("DOMContentLoaded", function () {
                     };
 
                     const searchValueMappings = {
+                        all_fields: "all_fields",
+                        "catalog:all_fields": "all_fields",
                         author: "author",
                         author_browse: "author",
                         at_browse: "author",
                         "catalog:author": "author",
-                        Author: "author",
-                        "Author-Title": "author",
                         subject: "subject",
                         subject_browse: "subject",
                         "catalog:subject": "subject",
-                        Subject: "subject",
                         publisher: "publisher",
                         "catalog:publisher": "publisher",
                         title: "title",
@@ -40,67 +36,37 @@ document.addEventListener("DOMContentLoaded", function () {
                         journaltitle: "journaltitle",
                         "catalog:journaltitle": "journaltitle",
                         "catalog:lc_callnum": "lc_callnum",
-                        "Call-Number": "lc_callnum",
                         callnumber_browse: "lc_callnum",
                         lc_callnum: "lc_callnum"
                     };
 
                     if (field.name in fieldMappings) {
-                        if (field.name === "browse_type" || field.name === "search_field" || field.name === "search_field_row") {
+                        if (field.name === "browse_type" || field.name === "search_field") {
                             if (field.value in searchValueMappings) {
-                                params.append("search_field_row[]", searchValueMappings[field.value]);
+                                advancedSearchLinkParams.set("search_field_row[]", searchValueMappings[field.value]);
                                 if (field.value === "title_starts") {
-                                    params.append("op_row[]", "begins_with");
+                                    advancedSearchLinkParams.set("op_row[]", "begins_with");
                                 }
                             }
                         } else {
-                            params.append(fieldMappings[field.name], field.value);
+                            advancedSearchLinkParams.set(fieldMappings[field.name], field.value);
                         }
-                    } else if (field.name !== "authenticity_token" && field.name !== "utf8") {
-                        params.append(field.name, field.value);
                     }
                 }
             });
 
             // Add q_row as a parameter if the search field has text
             if (hasSearchText) {
-                params.append("q_row[]", searchField.value.trim()); // Append q_row
+                advancedSearchLinkParams.set("q_row[]", searchField.value.trim()); // Append q_row
             }
 
-            // Append other advanced search parameters if present
-            const opRow = document.querySelectorAll("[name='op_row[]']");
-            const searchFieldRow = document.querySelectorAll("[name='search_field_row[]']");
-            const booleanRow = document.querySelectorAll("[name='boolean_row[]']");
-            const facetFields = document.querySelectorAll("[name^='f[']");
-
-            opRow.forEach((field, index) => params.append(`op_row[${index}]`, field.value));
-            searchFieldRow.forEach((field, index) => params.append(`search_field_row[${index}]`, field.value));
-            booleanRow.forEach((field, index) => params.append(`boolean_row[${index}]`, field.value));
-
-            // Handle facets, including f[format]
-            const uniqueFacets = new Set();
-            facetFields.forEach((field) => {
-                const match = field.name.match(/^f\[(.+)\]$/); // Match f[key] format
-                if (match && match[1]) {
-                    const key = `f[${match[1]}]`;
-                    const value = field.value;
-                    const facetEntry = `${key}=${value}`;
-
-                    if (!uniqueFacets.has(facetEntry)) {
-                        uniqueFacets.add(facetEntry);
-                        params.append(key, value);
-                    }
-                }
-            });
             // Update link href to use the /edit path
-            advancedSearchLink.href = `/edit?${params.toString()}`;
+            advancedSearchLink.href = `/edit?${advancedSearchLinkParams.toString()}`;
         };
 
         formFields.forEach((field) => {
             field.addEventListener("input", updateAdvancedSearchLink);
             field.addEventListener("change", updateAdvancedSearchLink);
         });
-        updateAdvancedSearchLink();
-        advancedSearchLink.addEventListener("click", updateAdvancedSearchLink);
     }
 });

--- a/blacklight-cornell/app/views/shared/_search_form.html.erb
+++ b/blacklight-cornell/app/views/shared/_search_form.html.erb
@@ -111,9 +111,9 @@
     <div class="search-nav col-12 col-lg-5">
       <ul class="nav nav-pills">
         <li>
-          <a id="advanced-search-link" href="/advanced">
+          <%= link_to advanced_search_edit_path(convert_to_advanced_params(params)), id: 'advanced-search-link' do %>
             <i class="fa fa-search" aria-hidden="true"></i>Advanced Search
-          </a>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/blacklight-cornell/app/views/single_search/index.html.erb
+++ b/blacklight-cornell/app/views/single_search/index.html.erb
@@ -9,7 +9,7 @@
               <%= render 'single_search/search_form' %>
             </div>
             <div class="advanced-search-link col-md-4">
-              <%= link_to 'Catalog Advanced Search', "/advanced", id: "advanced-search-link" %>
+              <%= link_to 'Catalog Advanced Search', advanced_search_edit_path(convert_to_advanced_params(params)), id: 'advanced-search-link' %>
             </div>
           </div>
         </div>

--- a/blacklight-cornell/spec/helpers/cornell_params_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/cornell_params_helper_spec.rb
@@ -3,6 +3,55 @@ require 'rails_helper'
 describe BrowseHelper do
   let(:blacklight_config) { CatalogController.blacklight_config }
 
+  describe '#convert_to_advanced_params' do
+    it 'returns empty hash when params are empty or does not contain relevant keys' do
+      expect(helper.convert_to_advanced_params({})).to eq({})
+      expect(helper.convert_to_advanced_params({ controller: 'catalog' })).to eq({})
+    end
+
+    it 'returns an empty q_row when q and authq are not present' do
+      params = { search_field: 'journaltitle' }
+      expected_params = { q_row: [''], search_field_row: ['journaltitle'] }
+      expect(helper.convert_to_advanced_params(params)).to eq(expected_params)
+    end
+
+    context 'simple search' do
+      it 'converts q to q_row and search_field to search_field_row' do
+        params = { q: 'test query', search_field: 'title' }
+        expected_params = { q_row: ['test query'], search_field_row: ['title'] }
+        expect(helper.convert_to_advanced_params(params)).to eq(expected_params)
+      end
+
+      it 'adds op_row when search_field = title_starts' do
+        params = { q: 'test query', search_field: 'title_starts' }
+        expected_params = { q_row: ['test query'], search_field_row: ['title'], op_row: ['begins_with'] }
+        expect(helper.convert_to_advanced_params(params)).to eq(expected_params)
+      end
+    end
+
+    context 'bento search' do
+      it 'converts q to q_row and sets default search_field' do
+        params = { q: 'test query' }
+        expected_params = { q_row: ['test query'], search_field_row: ['all_fields'] }
+        expect(helper.convert_to_advanced_params(params)).to eq(expected_params)
+      end
+    end
+
+    context 'browse' do
+      it 'converts authq to q_row and browse_type to search_field_row' do
+        params = { authq: 'TP640', browse_type: 'Call-Number' }
+        expected_params = { q_row: ['TP640'], search_field_row: ['lc_callnum'] }
+        expect(helper.convert_to_advanced_params(params)).to eq(expected_params)
+      end
+
+      it 'does not error when invalid browse_type is provided' do
+        params = { authq: 'TP640', browse_type: 'InvalidType' }
+        expected_params = { q_row: ['TP640'], search_field_row: [nil] }
+        expect(helper.convert_to_advanced_params(params)).to eq(expected_params)
+      end
+    end
+  end
+
   describe '#remove_blank_rows' do
     context 'single row query' do
       context 'query is not blank' do


### PR DESCRIPTION
Fixes: https://culibrary.atlassian.net/browse/DACCESS-624

- Sets advanced search form prefill values from relevant search session params
- Only dynamically updates prefill values for input#q, select#search_field and input#authq, select#browse_type (for browse)
- Adds All Fields search field mapping for dynamic changes to selected search field in dropdown