### PR TITLE
DACCESS-607 - Retain facets from previous search session

### DIFF
--- a/blacklight-cornell/app/helpers/cornell_catalog_helper.rb
+++ b/blacklight-cornell/app/helpers/cornell_catalog_helper.rb
@@ -22,7 +22,7 @@ module CornellCatalogHelper
   end
 
   def advanced_search?
-    params[:q_row].present? || params[:f_inclusive].present?
+    params[:q_row].present?
   end
 
   def process_online_title(title)

--- a/blacklight-cornell/app/helpers/cornell_params_helper.rb
+++ b/blacklight-cornell/app/helpers/cornell_params_helper.rb
@@ -396,16 +396,6 @@ def make_show_query(params)
   params[:show_query] = showquery
 end
 
-  def qtoken(q_string)
-    qnum = q_string.count('"')
-    if qnum % 2 == 1
-      qstring = qstring + '"'
-    end
-      p = q_string.split(/\s(?=(?:[^"]|"[^"]*")*$)/)
-    return p
-
-  end
-
   # DACCESS-215
   def query_has_pub_date_facet?
     return params[:range].present? && params[:range].keys.include?('pub_date_facet')

--- a/blacklight-cornell/features/catalog_search/facets.feature
+++ b/blacklight-cornell/features/catalog_search/facets.feature
@@ -112,3 +112,27 @@ Feature: Facets
 Scenario: Filtering searches by facets that are not available in the public ui
 	When I literally go to ?f[availability_facet][]=Checked%20out
 	Then I should get 10 results
+
+Scenario: Searching multiple times retains the previous search session's facets
+  When I literally go to ?boolean_row%5B1%5D=AND&f_inclusive%5Bformat%5D%5B%5D=Book&f_inclusive%5Bformat%5D%5B%5D=Journal%2FPeriodical&f_inclusive%5Blanguage_facet%5D%5B%5D=English&f_inclusive%5Blanguage_facet%5D%5B%5D=French&op_row%5B%5D=AND&op_row%5B%5D=AND&q=&q_row%5B%5D=Canada&q_row%5B%5D=&range%5Bpub_date_facet%5D%5Bbegin%5D=1960&range%5Bpub_date_facet%5D%5Bend%5D=2000&search_field=advanced&search_field_row%5B%5D=all_fields&search_field_row%5B%5D=all_fields
+  Then I should get results
+  And it should contain filter "All Fields" with value "Canada"
+  And it should contain filter "Format" with value "Book OR Journal/Periodical"
+  And it should contain filter "Language" with value "English OR French"
+  And I should see the label 'Modify advanced search'
+  And click on first link "Algebras and orders"
+  Then I should see the label 'Algebras and orders'
+  And I fill in the search box with 'beef'
+  And I press 'search'
+  Then I should get results
+  And it should contain filter "All Fields" with value "beef"
+  And it should contain filter "Format" with value "Book OR Journal/Periodical"
+  And it should contain filter "Language" with value "English OR French"
+  And I should not see the label 'Modify advanced search'
+  And I fill in the search box with 'law'
+  And I press 'search'
+  Then I should get results
+  And it should contain filter "All Fields" with value "law"
+  And it should contain filter "Format" with value "Book OR Journal/Periodical"
+  And it should contain filter "Language" with value "English OR French"
+  And I should not see the label 'Modify advanced search'


### PR DESCRIPTION
Relevant: https://culibrary.atlassian.net/browse/DACCESS-607 and https://github.com/cul-it/blacklight-cornell/pull/2309

Previous behavior:

1. Conduct an advanced search with facets applied, e.g. /?advanced_query=yes&boolean_row%5B1%5D=AND&commit=Search&f_inclusive%5Bformat%5D%5B%5D=Book&f_inclusive%5Bformat%5D%5B%5D=Journal%2FPeriodical&f_inclusive%5Blanguage_facet%5D%5B%5D=English&f_inclusive%5Blanguage_facet%5D%5B%5D=French&op_row%5B%5D=AND&op_row%5B%5D=AND&q=&q_row%5B%5D=Canada&q_row%5B%5D=&range%5Bpub_date_facet%5D%5Bbegin%5D=1960&range%5Bpub_date_facet%5D%5Bend%5D=2000&search_field=advanced&search_field_row%5B%5D=all_fields&search_field_row%5B%5D=all_fields&sort=score+desc%2C+pub_date_sort+desc%2C+title_sort+asc&utf8=✓
1. Click on any item from the search results
1. Conduct a simple search from the item view, e.g. /catalog?utf8=✓&advanced_query=yes&f_inclusive%5Bformat%5D%5B%5D=Book&f_inclusive%5Bformat%5D%5B%5D=Journal%2FPeriodical&f_inclusive%5Blanguage_facet%5D%5B%5D=English&f_inclusive%5Blanguage_facet%5D%5B%5D=French&range%5Bpub_date_facet%5D%5Bbegin%5D=1960&range%5Bpub_date_facet%5D%5Bend%5D=2000&search_field_row%5B%5D=all_fields&search_field_row%5B%5D=all_fields&sort=score+desc%2C+pub_date_sort+desc%2C+title_sort+asc&controller=catalog&action=index&per_page=20&q=all_fields+%3D+&total=3&counter=1&q=wildlife&search_field=all_fields
1. WACKY BEHAVIOR: "Advanced Search" link appears at same time as "Modify advanced search" button: <img width="1137" height="237" alt="Screenshot 2025-08-19 at 3 35 54 PM" src="https://github.com/user-attachments/assets/a6ffc09d-a0b7-4c0d-8eb8-cc69b7236cde" />
1. Click on “Modify advanced search”
1. BUG: Simple search query doesn’t prefill advanced search form

NEW behavior:
Repeat steps above, but wacky behavior of step 4 has now been updated so that "Modify advanced search" button is removed:
<img width="1152" height="203" alt="Screenshot 2025-08-19 at 3 37 55 PM" src="https://github.com/user-attachments/assets/f0e1575a-99d1-49b9-abfa-9b82aa5cca5f" />
And clicking on the "Advanced Search" link properly populates the advanced search form with the new query.

This PR also removes an unused and unrelated helper method - I can move to a separate PR if this is annoying to include!