### PR TITLE
DACCESS-626: make start over button more prominent

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
@@ -217,6 +217,16 @@
 	}
 }
 
+#startOverLink::before {
+	display: inline-block;
+  	text-rendering: auto;
+  	-webkit-font-smoothing: antialiased;
+	font-family: 'FontAwesome';
+	content: '\f0a8';
+	margin-right: .25rem;
+	color: $cornell-primary;
+}
+
 // MEDIA QUERIES
 // -------------------------
 

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
@@ -226,6 +226,9 @@
 	margin-right: .25rem;
 	color: $cornell-primary;
 }
+#startOverLink:hover {
+	background: $light-tan;
+}
 
 // MEDIA QUERIES
 // -------------------------

--- a/blacklight-cornell/app/views/catalog/_constraints.html.erb
+++ b/blacklight-cornell/app/views/catalog/_constraints.html.erb
@@ -7,7 +7,7 @@
         <%= link_to 'Modify advanced search »', url_for(:controller=>"advanced_search", :action=>"edit", :q_row=>params[:q_row], :op_row=>params[:op_row], :search_field_row=>params[:search_field_row], :boolean_row=>params[:boolean_row], :f=>params[:f], :f_inclusive=>params[:f_inclusive], :range=>params[:range]), :class=>"btn btn-search" %>
       </div>
     <% end %>
-  	<%=link_to t('blacklight.search.start_over'), url_for(:action=>'index'), :id=>"startOverLink", :class=>"btn btn-light" %>
+  	<%=link_to t('blacklight.search.start_over'), url_for(:action=>'index'), :id=>"startOverLink", :class=>"btn" %>
     <span class="constraints-label hidden"><% t('blacklight.search.filters.title') %></span>
     <% if params[:q_row].nil? && params[:f].nil? && params[:f_inclusive].nil? && params[:range].nil? %>
       <% if params[:search_field] && params[:search_field] != 'advanced'%>


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-626

### Purpose

Currently the "Start over" button gets a bit lost in the constraints, especially when many are selected. Make the button stand out a bit more.

### Changes

- Add a left arrow icon in the Cornell red color. (This is the same icon used in the "back to results" link on the item view, so there is some UI consistency.)
- Remove the background color of the button. This adds a subtle separation from the buttons, while also allowing other more important elements to stand out.

Screenshot of change:

<img width="1202" height="666" alt="new-start-over" src="https://github.com/user-attachments/assets/1cfdba57-58ee-4fcf-a68a-2155db08df89" />

