### PR TITLE
Install aws-sdk-s3 gem for get_env.rb

### DIFF
--- a/docker/bookworm/Dockerfile
+++ b/docker/bookworm/Dockerfile
@@ -104,6 +104,7 @@ COPY ./blacklight-cornell/Gemfile ./blacklight-cornell/Gemfile.lock ./
 RUN bundle config set --local with "${RAILS_ENV}" && \
     bundle config set --local without "${BUNDLE_WITHOUT}" && \
     bundle install && \
+    gem install aws-sdk-s3 && \
     rm -rf ${BUNDLE_PATH}/cache/*.gem && \
     find ${BUNDLE_PATH}/ -name "*.c" -delete && \
     find ${BUNDLE_PATH}/ -name "*.o" -delete


### PR DESCRIPTION
We may want to make that script a rake task so we don't have to install that gem twice.