### PR TITLE
Revert back to normal env file for jenkins test jobs

### DIFF
--- a/jenkins/container-tests.sh
+++ b/jenkins/container-tests.sh
@@ -7,7 +7,7 @@ echo "**************************************************************************
 source jenkins/environment.sh
 
 sudo systemctl start docker
-cp /cul/data/jenkins/environments/blacklight-cornell-solr9.env container_env_test.env
+cp /cul/data/jenkins/environments/blacklight-cornell.env container_env_test.env
 
 export COVERAGE=on
 export RAILS_ENV_FILE=./container_env_test.env

--- a/jenkins/cucumber-features.sh
+++ b/jenkins/cucumber-features.sh
@@ -6,7 +6,7 @@ echo "**************************************************************************
 source jenkins/environment.sh
 
 sudo systemctl start docker
-cp /cul/data/jenkins/environments/blacklight-cornell-solr9.env container_env_test.env
+cp /cul/data/jenkins/environments/blacklight-cornell.env container_env_test.env
 
 export COVERAGE=on
 export RAILS_ENV_FILE=./container_env_test.env

--- a/jenkins/environment.sh
+++ b/jenkins/environment.sh
@@ -27,7 +27,7 @@ source /etc/profile.d/rvm.sh
 rvm use "$RUBYVERSION"
 
 # Copy environment file
-cp /cul/data/jenkins/environments/blacklight-cornell-solr9.env .env
+cp /cul/data/jenkins/environments/blacklight-cornell.env .env
 
 # Add DEBUG_USER to environment file
 echo "DEBUG_USER=${DEBUG_USER}" >>.env

--- a/jenkins/rspec.sh
+++ b/jenkins/rspec.sh
@@ -5,7 +5,7 @@ echo "Running RSpec tests in container"
 echo "*********************************************************************************"
 source jenkins/environment.sh
 
-cp /cul/data/jenkins/environments/blacklight-cornell-solr9.env container_env_test.env
+cp /cul/data/jenkins/environments/blacklight-cornell.env container_env_test.env
 
 export COVERAGE=on
 export RAILS_ENV_FILE=./container_env_test.env


### PR DESCRIPTION
I had temporarily pointed the env file for the jenkins test jobs to one that had solr 9 values as part of https://github.com/cul-it/blacklight-cornell/pull/2321, but I can switch it back to the normal one now that it's been merged.

Will delete blacklight-cornell-solr9.env on jenkins after this is merged.