### PR TITLE
DACCESS-750 / DACCESS-755 Resolve deprecation warnings for query_has_constraints? and filter_params

### DIFF
--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -282,21 +282,21 @@ class CatalogController < ApplicationController
     }, if: :has_search_parameters?
 
     # Facets not shown in side bar, but available for filtering
-    config.add_facet_field 'author_corp_roman_facet', :show => false, :label => "Author: Corporate Name (Roman)"
-    config.add_facet_field 'author_event_roman_facet', :show => false, :label => "Author: Event (Roman)"
-    config.add_facet_field 'author_pers_roman_facet', :show => false, :label => "Author: Personal Name (Roman)"
-    config.add_facet_field 'authortitle_facet', :show => false, :label => "Author-Title"
-    config.add_facet_field 'availability_facet', :show => false, :label => "Availability"
-    config.add_facet_field 'collection', :show => false, :label => "Collection"
-    config.add_facet_field 'ebsco_title_facet', :show => false, :label => "EBSCO Title"
-    config.add_facet_field 'etas_facet', :show => false, :label => "Emergency Temporary Access Service (ETAS)"
-    config.add_facet_field 'format_main_facet', :show => false, :label => "Format Main"
-    config.add_facet_field 'lc_alpha_facet', :show => false, :label => 'Call Number', :limit => 5
-    config.add_facet_field 'source', :show => false, :label => 'Source'
-    config.add_facet_field 'statcode_facet', :show => false, :label => "Stat Code"
-    config.add_facet_field 'subject_overlay_facet', :show => false, :label => 'Subject Overlay'
-    config.add_facet_field 'subject_work_lc_facet', :show => false, :label => "Subject: Work LC"
-    config.add_facet_field 'workid_facet', :show => false, :label => 'Work'
+    config.add_facet_field 'author_corp_roman_facet', show: false, label: "Author: Corporate Name (Roman)"
+    config.add_facet_field 'author_event_roman_facet', show: false, label: "Author: Event (Roman)"
+    config.add_facet_field 'author_pers_roman_facet', show: false, label: "Author: Personal Name (Roman)"
+    config.add_facet_field 'authortitle_facet', show: false, label: "Author-Title"
+    config.add_facet_field 'availability_facet', show: false, label: "Availability"
+    config.add_facet_field 'collection', show: false, label: "Collection"
+    config.add_facet_field 'ebsco_title_facet', show: false, label: "EBSCO Title"
+    config.add_facet_field 'etas_facet', show: false, label: "Emergency Temporary Access Service (ETAS)"
+    config.add_facet_field 'format_main_facet', show: false, label: "Format Main"
+    config.add_facet_field 'lc_alpha_facet', show: false, label: 'Call Number', limit: 5
+    config.add_facet_field 'source', show: false, label: 'Source'
+    config.add_facet_field 'statcode_facet', show: false, label: "Stat Code"
+    config.add_facet_field 'subject_overlay_facet', show: false, label: 'Subject Overlay'
+    config.add_facet_field 'subject_work_lc_facet', show: false, label: "Subject: Work LC"
+    config.add_facet_field 'workid_facet', show: false, label: 'Work'
 
     # Generate staff-only subject facet fields based on the given pattern
     %w[topic genr pers corp event era geo gen sub].each do |type|

--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -220,9 +220,7 @@ class CatalogController < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
-    #if  RAILS_ENV = 'development'
-    #config.add_facet_field 'availability_facet', :label => 'Availability Status', :limit => 30, :collapse => false
-    #end
+
     config.add_facet_field 'online', :label => 'Access', :limit => 2, :collapse => false
     config.add_facet_field 'format',
                            label: 'Format',
@@ -249,8 +247,6 @@ class CatalogController < ApplicationController
                            if: :has_search_parameters?,
                            advanced_search_component: AdvancedRangeLimitComponent,
                            advanced_search_order: 0
-
-    config.add_facet_field 'workid_facet', :label => 'Work', :show => false
     config.add_facet_field 'language_facet',
                            label: 'Language',
                            limit: 5,
@@ -263,9 +259,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'fast_era_facet', :label => 'Subject: Era', :limit => 5, if: :has_search_parameters?
     config.add_facet_field 'fast_genre_facet', :label => 'Genre', :limit => 5, if: :has_search_parameters?
     config.add_facet_field 'subject_content_facet', :label => 'Fiction/Non-Fiction', :limit => 5, if: :has_search_parameters?
-    config.add_facet_field 'lc_alpha_facet', :label => 'Call Number', :limit => 5, :show => false
     config.add_facet_field 'hierarchy_facet', :hierarchy => true
-    config.add_facet_field 'authortitle_facet', :show => false, :label => "Author-Title"
     # Display only top 10 call number levels server-side, render remainder via ajax
     config.add_facet_field 'lc_callnum_facet',
                            if: :has_search_parameters?,
@@ -281,25 +275,32 @@ class CatalogController < ApplicationController
      }
  }
 
-    config.add_facet_field 'collection', :show => false
-
-
     config.add_facet_field 'acquired_dt_query',  label: 'Date Acquired', query: {
       last_1_week: { label: 'Since last week', fq: "acquired_dt:[NOW-14DAY TO NOW-7DAY]"},
       last_1_month: { label: 'Since last month', fq: "acquired_dt:[NOW-30DAY TO NOW-7DAY]"},
       last_1_years: { label: 'Since last year', fq: "acquired_dt:[NOW-1YEAR TO NOW-7DAY]"}
     }, if: :has_search_parameters?
 
-
-    # config.add_facet_field 'facet', :multiple => true
-    # config.add_facet_field 'first_facet,last_facet', :pivot => ['first_facet', 'last_facet']
-    # config.add_facet_field 'my_query_field', :query => { 'label' => 'value:1', 'label2' => 'value:2'}
-    # config.add_facet_field 'facet', :single => true
-    # config.add_facet_field 'facet', :tag => 'my_tag', :ex => 'my_tag'
+    # Facets not shown in side bar, but available for filtering
+    add_staffonly_subject_facets(config)
+    config.add_facet_field 'author_corp_roman_facet', :show => false, :label => "Author: Corporate Name (Roman)"
+    config.add_facet_field 'author_event_roman_facet', :show => false, :label => "Author: Event (Roman)"
+    config.add_facet_field 'author_pers_roman_facet', :show => false, :label => "Author: Personal Name (Roman)"
+    config.add_facet_field 'authortitle_facet', :show => false, :label => "Author-Title"
+    config.add_facet_field 'availability_facet', :show => false, :label => "Availability"
+    config.add_facet_field 'collection', :show => false, :label => "Collection"
+    config.add_facet_field 'ebsco_title_facet', :show => false, :label => "EBSCO Title"
+    config.add_facet_field 'etas_facet', :show => false, :label => "Emergency Temporary Access Service (ETAS)"
+    config.add_facet_field 'format_main_facet', :show => false, :label => "Format Main"
+    config.add_facet_field 'lc_alpha_facet', :show => false, :label => 'Call Number', :limit => 5
+    config.add_facet_field 'source', :show => false, :label => 'Source'
+    config.add_facet_field 'statcode_facet', :show => false, :label => "Stat Code"
+    config.add_facet_field 'subject_overlay_facet', :show => false, :label => 'Subject Overlay'
+    config.add_facet_field 'subject_work_lc_facet', :show => false, :label => "Subject: Work LC"
+    config.add_facet_field 'workid_facet', :show => false, :label => 'Work'
 
     #config.default_solr_params[:'facet.field'] = config.facet_fields.keys
     config.add_facet_fields_to_solr_request!
-
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -880,6 +881,19 @@ class CatalogController < ApplicationController
     {
       current_user: current_user
     }
+  end
+
+  # Generate staff-only subject facet fields dynamically based on the given pattern
+  def add_staffonly_subject_facets(config)
+    facet_types = %w[topic genr pers corp event era geo gen sub]
+    facet_sources = %w[lc lcgft lcjsh fast aat agrovoc homoit mesh rbmscv zst local unk other]
+  
+    facet_types.each do |type|
+      facet_sources.each do |source|
+        facet_field_name = "subject_#{type}_#{source}_facet"
+        config.add_facet_field facet_field_name, show: false, label: "Subject: #{type.capitalize} (#{source.upcase})"
+      end
+    end
   end
 
 end

--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -282,7 +282,6 @@ class CatalogController < ApplicationController
     }, if: :has_search_parameters?
 
     # Facets not shown in side bar, but available for filtering
-    add_staffonly_subject_facets(config)
     config.add_facet_field 'author_corp_roman_facet', :show => false, :label => "Author: Corporate Name (Roman)"
     config.add_facet_field 'author_event_roman_facet', :show => false, :label => "Author: Event (Roman)"
     config.add_facet_field 'author_pers_roman_facet', :show => false, :label => "Author: Personal Name (Roman)"
@@ -298,6 +297,14 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_overlay_facet', :show => false, :label => 'Subject Overlay'
     config.add_facet_field 'subject_work_lc_facet', :show => false, :label => "Subject: Work LC"
     config.add_facet_field 'workid_facet', :show => false, :label => 'Work'
+
+    # Generate staff-only subject facet fields based on the given pattern
+    %w[topic genr pers corp event era geo gen sub].each do |type|
+      %w[lc lcgft lcjsh fast aat agrovoc homoit mesh rbmscv zst local unk other].each do |source|
+        facet_field_name = "subject_#{type}_#{source}_facet"
+        config.add_facet_field facet_field_name, show: false, label: "Subject: #{type.capitalize} #{source.upcase}"
+      end
+    end
 
     #config.default_solr_params[:'facet.field'] = config.facet_fields.keys
     config.add_facet_fields_to_solr_request!
@@ -882,18 +889,4 @@ class CatalogController < ApplicationController
       current_user: current_user
     }
   end
-
-  # Generate staff-only subject facet fields dynamically based on the given pattern
-  def add_staffonly_subject_facets(config)
-    facet_types = %w[topic genr pers corp event era geo gen sub]
-    facet_sources = %w[lc lcgft lcjsh fast aat agrovoc homoit mesh rbmscv zst local unk other]
-  
-    facet_types.each do |type|
-      facet_sources.each do |source|
-        facet_field_name = "subject_#{type}_#{source}_facet"
-        config.add_facet_field facet_field_name, show: false, label: "Subject: #{type.capitalize} (#{source.upcase})"
-      end
-    end
-  end
-
 end

--- a/blacklight-cornell/app/models/search_builder.rb
+++ b/blacklight-cornell/app/models/search_builder.rb
@@ -5,7 +5,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   include BlacklightRangeLimit::RangeLimitBuilder
 
   self.default_processor_chain += [:sortby_title_when_browsing, :sortby_callnum,
-                                   :set_fl, :set_fq, :set_query,
+                                   :set_fl, :set_query,
                                    :homepage_default, :reset_facet_limit, :group_bento_results]
 
   DEFAULT_BOOLEAN = 'AND'
@@ -49,22 +49,6 @@ class SearchBuilder < Blacklight::SearchBuilder
   def set_fl solr_parameters
     # Overrides default fl set in solrconfig to return all stored fields
     solr_parameters[:fl] = '*' if blacklight_params['controller'] == 'bookmarks' || blacklight_params['format'].present? || blacklight_params['controller'] == 'book_bags'
-  end
-
-  # Add any facets not already defined by blacklight to the solr fq
-  # Useful for backend cataloging work
-  def set_fq solr_parameters
-    if blacklight_params[:f].present?
-      solr_parameters[:fq] = solr_parameters[:fq] || []
-      blacklight_params[:f].each do |key, value|
-        unless blacklight_config.facet_fields.keys.include?(key)
-          value.each do |val|
-            fq_string = "{!term f=#{key.to_s}}#{val}"
-            solr_parameters[:fq] << fq_string
-          end
-        end
-      end
-    end
   end
 
   # Sets solr q param from search fields, booleans, and ops (simple, advanced, and bento search)

--- a/blacklight-cornell/lib/blacklight_cornell/search_state.rb
+++ b/blacklight-cornell/lib/blacklight_cornell/search_state.rb
@@ -2,7 +2,7 @@ module BlacklightCornell
   class SearchState < Blacklight::SearchState
     # Override has_constraints? to check :q_row for advanced search
     def has_constraints?
-      !(query_param.blank? && advanced_query_param.blank? && filter_params.blank? && filters.blank? && clause_params.blank?)
+      !(query_param.blank? && advanced_query_param.blank? && filters.blank? && clause_params.blank?)
     end
 
     def advanced_query_param

--- a/blacklight-cornell/spec/controllers/catalog_controller_spec.rb
+++ b/blacklight-cornell/spec/controllers/catalog_controller_spec.rb
@@ -268,4 +268,13 @@ RSpec.describe CatalogController, type: :controller do
       expect(session[:history].count).to eq(1)
     end
   end
+
+  describe '#add_staffonly_subject_facets' do
+    it 'adds staff-only subject facets to the Blacklight configuration' do
+      CatalogController.new.send(:add_staffonly_subject_facets, bl_config)
+      expect(bl_config.facet_fields).to include('subject_corp_lc_facet')
+      expect(bl_config.facet_fields['subject_corp_lc_facet'].show).to eq(false)
+      end
+    end
+  end
 end

--- a/blacklight-cornell/spec/controllers/catalog_controller_spec.rb
+++ b/blacklight-cornell/spec/controllers/catalog_controller_spec.rb
@@ -273,7 +273,6 @@ RSpec.describe CatalogController, type: :controller do
     it 'added to the Blacklight configuration' do
       expect(bl_config.facet_fields).to include('subject_corp_lc_facet')
       expect(bl_config.facet_fields['subject_corp_lc_facet'].show).to eq(false)
-      end
     end
   end
 end

--- a/blacklight-cornell/spec/controllers/catalog_controller_spec.rb
+++ b/blacklight-cornell/spec/controllers/catalog_controller_spec.rb
@@ -269,9 +269,8 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
-  describe '#add_staffonly_subject_facets' do
-    it 'adds staff-only subject facets to the Blacklight configuration' do
-      CatalogController.new.send(:add_staffonly_subject_facets, bl_config)
+  describe 'Staff-only subject facets' do
+    it 'added to the Blacklight configuration' do
       expect(bl_config.facet_fields).to include('subject_corp_lc_facet')
       expect(bl_config.facet_fields['subject_corp_lc_facet'].show).to eq(false)
       end

--- a/blacklight-cornell/spec/models/search_builder_spec.rb
+++ b/blacklight-cornell/spec/models/search_builder_spec.rb
@@ -2225,44 +2225,6 @@ RSpec.describe SearchBuilder, type: :model do
     end
   end
 
-  describe '#set_fq' do
-    before do
-      allow(search_builder).to receive(:blacklight_params) { blacklight_params }
-    end
-
-    context 'empty q and search_field' do
-      let(:blacklight_params) { {
-        f: {
-          'author_facet' => ['Bayerische Staatsbibliothek'],
-          'subject_topic_lc_facet' => ['Block-books, Tibetan']
-        }
-      } }
-
-      it 'populates solr fq' do
-        solr_params = { fq: ['{!term f=author_facet}Bayerische Staatsbibliothek'] }
-        search_builder.set_fq(solr_params)
-        expect(solr_params[:fq]).to eq(['{!term f=author_facet}Bayerische Staatsbibliothek',
-                                        '{!term f=subject_topic_lc_facet}Block-books, Tibetan'])
-      end
-    end
-
-    context 'existing q and search_field' do
-      let(:blacklight_params) { {
-        f: {
-          'subject_topic_lc_facet' => ['Block-books, Tibetan']
-        },
-        q: 'tibetan',
-        search_field: 'all_fields'
-      } }
-
-      it 'populates solr fq' do
-        solr_params = {}
-        search_builder.set_fq(solr_params)
-        expect(solr_params[:fq]).to eq(['{!term f=subject_topic_lc_facet}Block-books, Tibetan'])
-      end
-    end
-  end
-
   describe '#group_bento_results' do
     let(:solr_params) { {
       q: '(("cats" AND "dogs") OR phrase:"cats dogs")',


### PR DESCRIPTION
Jira: https://culibrary.atlassian.net/browse/DACCESS-750, https://culibrary.atlassian.net/browse/DACCESS-755

Addresses the following deprecation warnings: 

`DEPRECATION WARNING: filter_params is deprecated and will be removed from a future release (Use #filters instead). (called from has_constraints? at /blacklight-cornell/lib/blacklight_cornell/search_state.rb:5)`

`DEPRECATION WARNING: query_has_constraints? is deprecated and will be removed from blacklight 8.0 (use search_state#has_constraints?).`

Changes include: 
- Removing old overrides that allow for facets that are undefined in the catalog controller to be used in BL queries
- Adding a defined safelist of non-public facets to the controller, including subject facets generated based on a pattern (let me know if there's a better place to put this logic)