### PR TITLE
DACCESS-899: accessibility fixes

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_item-record.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_item-record.scss
@@ -3,22 +3,22 @@
 .return-link {
 	display: inline-block;
 	margin-bottom: .6em;
-	font-size: 12px;
+	font-size: .9rem;
 }
 
 .document-header {
 	margin-bottom: 1.5em;
 }
 
-h3.subtitle,
-h3.responsibility {
-	font-size: 16px;
+.subtitle,
+.responsibility {
+	font-size: 1rem;
 	font-weight: normal;
 	line-height: 1.2em;
 	margin-bottom: 1em;
 	margin-top: 0;
 }
-h3.responsibility {
+.responsibility {
 	color: $medium-gray;
 }
 

--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -158,13 +158,13 @@
                           <% if parsed_json['titleid'].present? %>
  	                        <span class="terms-of-use">
  	                        <%#= @document.inspect %>
-	                          <span class="fa fa-chevron-right" aria-hiden="true"></span>
+	                          <span class="fa fa-chevron-right" aria-hidden="true"></span>
                               <a href="/catalog/new_tou/<%= parsed_json['titleid'] %>/<%= @document['id']	%> ">Terms of use</a>
  		                    </span>
                           <% else %>
 	                        <% if link["dbcode"].present? && link["providercode"].present? %>
 	                          <span class="terms-of-use">
-	                            <span class="fa fa-chevron-right" aria-hiden="true"></span>
+	                            <span class="fa fa-chevron-right" aria-hidden="true"></span>
 		                        <a href="/catalog/tou/<%= @document[:id] %>/<%= link["providercode"] %>/<%= link["dbcode"] %>">Terms of use</a>
 		                        <%#= holdings_json.inspect  %>
 		                         <% if restrictions_display.present? %>

--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -29,10 +29,10 @@
     <h2><%= @title %></h2>
   <% end %>
   <% if @subtitle.present? %>
-    <h3 class="subtitle"><%= @subtitle %></h3>
+    <div class="subtitle"><%= @subtitle %></div>
   <% end %>
   <% if responsibility.present? %>
-    <h3 class="responsibility"><%= responsibility.join('; ') %></h3>
+    <div class="responsibility"><%= responsibility.join('; ') %></div>
   <% end %>
   </div>
   <div class="row">

--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -37,339 +37,334 @@
   </div>
   <div class="row">
     <div class="col-md-4 order-md-8">
-	  <div class="availability card">
-	    <div class="card-header">
-	      Availability
-	    </div>
-	    <div class="card-block">
-			<%# Determine if the request should be made through the catalog or the Aspace PUI %>
-			<% pui_url = aspace_pui_url(@document) %>
-			<% url_findingaid_displays = [] %>
+			<div class="availability card">
+				<div class="card-header">
+					Availability
+				</div>
+				<div class="card-block">
+					<%# Determine if the request should be made through the catalog or the Aspace PUI %>
+					<% pui_url = aspace_pui_url(@document) %>
+					<% url_findingaid_displays = [] %>
 
-			<% if pui_url.present? %>
-				<%# Item is in Aspace so replace static finding aid with link to the PUI %>
-				<% url_findingaid_displays = render_display_link :value => [pui_url], :field => 'url_findingaid_display', :format => 'default' %>
-				
-				<%# DACCESS-828 show multiple finding aids, filtering out 'resolver.library.cornell.edu' %>
-				<% if @document['url_findingaid_display'].present? %>
-					<% additional_links = Array(render_display_link(document: @document, field: 'url_findingaid_display', format: 'default')) %>
-					<% additional_links.reject! { |link| link.include?('resolver.library.cornell.edu') } %>
-					<% if additional_links.any? %>
-						<% url_findingaid_displays.concat(additional_links) %> 
+					<% if pui_url.present? %>
+						<%# Item is in Aspace so replace static finding aid with link to the PUI %>
+						<% url_findingaid_displays = render_display_link :value => [pui_url], :field => 'url_findingaid_display', :format => 'default' %>
+
+						<%# DACCESS-828 show multiple finding aids, filtering out 'resolver.library.cornell.edu' %>
+						<% if @document['url_findingaid_display'].present? %>
+							<% additional_links = Array(render_display_link(document: @document, field: 'url_findingaid_display', format: 'default')) %>
+							<% additional_links.reject! { |link| link.include?('resolver.library.cornell.edu') } %>
+							<% if additional_links.any? %>
+								<% url_findingaid_displays.concat(additional_links) %>
+							<% end %>
+						<% end %>
+					<% elsif @document['url_findingaid_display'].present? %>
+						<%# Item is not in Aspace so render finding aids from the document %>
+						<% url_findingaid_displays = render_display_link :document => @document, :field => 'url_findingaid_display', :format => 'default' %>
 					<% end %>
-				<% end %>
-			<% elsif @document['url_findingaid_display'].present? %>
-				<%# Item is not in Aspace so render finding aids from the document %> 
-				<% url_findingaid_displays = render_display_link :document => @document, :field => 'url_findingaid_display', :format => 'default' %>
-			<% end %>
-			<% if url_findingaid_displays.present? %>
-				<div class="url_findingaid_display" id="finding_aid">
-					<% url_findingaid_displays.each do |url_findingaid_display| %>
-					<div class="url_findingaid_link">
-						<i class="fa fa-check" aria-hidden="true"></i>
-						<%= url_findingaid_display %>
+					<% if url_findingaid_displays.present? %>
+						<div class="url_findingaid_display" id="finding_aid">
+							<% url_findingaid_displays.each do |url_findingaid_display| %>
+								<div class="url_findingaid_link">
+									<i class="fa fa-check" aria-hidden="true"></i>
+									<%= url_findingaid_display %>
+								</div>
+							<% end %>
+						</div>
+					<% end %>
+
+					<% summary_holdings = '' %>
+					<% if is_online?(@document) %>
+						<div class="holdings-online">
+							<div class="online-label">
+								<i class="fa fa-check" aria-hidden="true"></i>Online
+							</div>
+
+							<% if @document["holdings_json"].present? %>
+									<%# holdings = JSON.parse(@document['holdings_record_display'][0]) %>
+									<%# getID = holdings["id"] %>
+									<%#= JSON.parse(@document["holdings_json"])[getID]["holdings"].inspect %>
+									<% holdings_json = JSON.parse(holdings_json) %>
+									<% has_online_links = holdings_json.any? do |key, value| %>
+										<% value["active"].nil? || (value["active"] == true && key != "1" && key != "2") && value["online"] == true && value["links"].present? %>
+									<% end %>
+									<%#= JSON.parse(@document["holdings_json"]).inspect %>
+									<%#= holdings_json[getID]["links"].inspect %>
+									<%#= holdings_json[getID]["links"][0]["description"].inspect %>
+									<%#= holdings.inspect %>
+									<% if has_online_links %>
+										<ul class="list-unstyled">
+										<% holdings_json.each do |key, value| %>
+										<% if holdings_json[key]["active"].nil? or holdings_json[key]["active"] == true && (key != "1" && key != "2") %>
+											<%#= value["online"].inspect %>
+											<% if value["online"] == true and value["links"].present? %>
+												<%#= value.inspect %>
+												<% value["links"].each do |link| %>
+													<%#= link["url"].inspect %>
+													<%#= link["description"].inspect %>
+													<% if link["description"].present? %>
+														<% label = link["description"] %>
+													<% else %>
+														<% label = t('blacklight.url.message') %>
+													<% end %>
+													<li>
+														<div class="online-link">
+															<% if label.include?("Temporary Access") %>
+																<% label = "Information for users about temporary access." %>
+															<% end %>
+															<%= link_to(process_online_title(label), link["url"].html_safe, {:class => 'online-access', :onclick => "javascript:_paq.push(['trackEvent', 'itemView', 'outlink']);"}) %>
+															<div class="message">
+																<%= summary_holdings.html_safe %>
+															</div>
+															<div class="message">
+																<%#= key.inspect %>
+																<% if key.present? %>
+																	<%#= value.inspect %>
+																	<% holdings = value %>
+																	<% getID = key %>
+																	<% if !value['holdings'].nil? %>
+																		<% sizer = value['holdings'].size %>
+																		<% if sizer != 1 %>
+																			Library has:<br/> <%= value['holdings'].join('<br>').html_safe %>
+																		<% else %>
+																			Library has: <%= value['holdings'][0].html_safe %>
+																		<% end %>
+																	<% end %>
+																	<% if !value['indexes'].nil? %>
+																		<% sizer = value['indexes'].size %>
+																		<% if sizer != 0 %>
+																			<br>Indexes: <%= value['indexes'].join('<br>').html_safe %>
+																		<% elsif value['indexes'][0].present? %>
+																			Indexes: <%= value['indexes'][0].html_safe %>
+																		<% end %>
+																	<% end %>
+																	<% if !value['notes'].nil? %>
+																		<% sizer = value['notes'].size %>
+																		<% if sizer != 0 %>
+																			<br>Notes: <%= value['notes'].join('<br>').html_safe %>
+																		<% elsif value['notes'][0].present? %>
+																			Notes: <%= value['notes'][0].html_safe %>
+																		<% end %>
+																	<% end %>
+																	<% if !value['supplements'].nil? %>
+																		<% sizer = value['supplements'].size %>
+																		<% if sizer != 0 %>
+																			<br>Supplements: <%= value['supplements'].join('<br>').html_safe %>
+																		<% elsif value['supplements'][0].present? %>
+																			Supplements: <%= value['supplements'][0].html_safe %>
+																		<% end %>
+																	<% end %>
+																<% end %>
+															</div>
+															<%#= @document['title_display'].inspect %>
+															<% parsed_json = JSON.parse(@document['url_access_json'][0]) %>
+															<%#= parsed_json['titleid'] %>
+															<%#= @document['id'] %>
+															<% if parsed_json['titleid'].present? %>
+																<span class="terms-of-use">
+																	<%#= @document.inspect %>
+																	<span class="fa fa-chevron-right" aria-hidden="true"></span>
+																	<a href="/catalog/new_tou/<%= parsed_json['titleid'] %>/<%= @document['id'] %> ">Terms of use</a>
+																</span>
+															<% else %>
+																<% if link["dbcode"].present? && link["providercode"].present? %>
+																	<span class="terms-of-use">
+																		<span class="fa fa-chevron-right" aria-hidden="true"></span>
+																		<a href="/catalog/tou/<%= @document[:id] %>/<%= link["providercode"] %>/<%= link["dbcode"] %>">Terms of use</a>
+																		<%#= holdings_json.inspect %>
+																		<% if restrictions_display.present? %>
+																			</div>
+																		<% end %>
+																		<% if !restrictions_display.present? %>
+																			<span class="access-restriction">
+																				<% if !holdings_json.nil? %>
+																					<% holdings_json.each do |k, holding| %>
+																						<% if !holdings_json[k]['links'].nil? %>
+																							<% if !holdings_json[k]['links'][0]['users'].nil? and holdings_json[k]['links'][0]['users'] != 'nil' %>
+																								<%#= holdings_json[k]['links'][0]['users'].inspect %>
+																								<%# Limiteds to <%= holdings_json[k]['links'][0]['users'].inspect '\%\>  simultaneous users %>
+																							<% end %>
+																						<% end %>
+																					<% end %>
+																				<% end %>
+																			</span>
+																		<% end %>
+																	</span>
+																<% else %>
+																<% end %>
+															<% end %>
+															<% if !restrictions_display.present? %>
+																</div>
+															<% end %>
+													</li>
+													<%# end %>
+												<% end %>
+											<% end %>
+										<% end %>
+										<% end %>
+										</ul>
+									<% end %>
+							<% end %>
+						</div>
+					<% end %>
+					<%# online-holdings %>
+
+					<%# end %>
+					<%# end online %>
+					<%# print holdings %>
+					<!-- solr verion of holdings -->
+					<div class="holdings">
+						<%#= @document.inspect %>
+						<% if !@document['holdings_json'].nil? %>
+							<% holdings = JSON.parse(@document['holdings_json']) %>
+							<%#= JSON.parse(holdings).to_s.inspect %>
+							<%#= getID.inspect %>
+							<%#= holdings[getID].inspect %>
+							<%#= holdings.inspect %>
+							<% circulating_items = [] %>
+							<% rare_items = [] %>
+							<% online_items = [] %>
+							<% holdings.each do |k, holding| %>
+								<%#= holdings[k]["active"].inspect %>
+								<% if !holding["restrictions"].nil? %>
+									<% holdings_restrictions = holding["restrictions"][0] %>
+								<% end %>
+								<% if !holding['links'].nil? and holding['links'][0]['users'].present? %>
+									<span class="access-restriction">
+										<h3>Restrictions</h3>
+										Limited to <%= holding['links'][0]['users'].inspect %> simultaneous users
+									</span>
+								<% end %>
+								<% if holdings[k]["active"].nil? or holdings[k]["active"] == true %>
+									<% if holding["location"].present? %>
+										<% if holding["location"]["name"].include?('Rare') || holding["location"]["name"].include?('Kheel') %>
+											<% rare_items << holding %>
+										<% else %>
+											<% circulating_items << holding %>
+										<% end %>
+									<% elsif holding["online"].present? %>
+										<% online_items << holding %>
+									<% end %>
+								<% end %>
+							<% end %>
+							<% if !circulating_items.blank? %>
+								<% items = circulating_items.sort_by { |e| e["location"]["name"] } %>
+								<% group = "Circulating" %>
+								<%= render 'holdings_group', :items => items, :group => group %>
+							<% end %>
+							<% if !rare_items.blank? %>
+								<% items = rare_items.sort_by { |e| e["location"]["name"] } %>
+								<% group = "Rare" %>
+								<% if circulating_items.present? %>
+									<h3>Rare Items</h3>
+								<% end %>
+								<%= render 'holdings_group', :items => items, :group => group %>
+							<% end %>
+						<% end %>
 					</div>
+					<%# access restrictions %>
+					<% if holdings_restrictions != "" %>
+						<span class="access-restriction">
+							<h3>Restrictions</h3>
+							<%= holdings_restrictions %>
+						</span>
 					<% end %>
+					<% if restrictions_display.present? %>
+						<span class="access-restriction">
+							<h3>Restrictions</h3>
+							<%= restrictions_display.map(&:inspect).join('; ').gsub('\\"', '') %>
+							<% if !@document['holdings_json'].nil? %>
+								<% holdings = JSON.parse(@document['holdings_json']) %>
+								<% holdings.each do |k, holding| %>
+									<% if !holdings[k]['links'].nil? and !holdings[k]['links'][0]['users'].nil? %>
+										Limited to <%= holdings[k]['links'][0]['users'].inspect %> simultaneous users
+									<% end %>
+								<% end %>
+							<% end %>
+						</span>
+					<% end %>
+					<%# end availability %>
+				</div>
+			</div>
+			<%# other forms %>
+			<% if other_availability_json.present? || workid_display.present? %>
+				<div class="availability card ">
+					<div class="card-header">
+						Other forms of this work
+					</div>
+					<div class="card-block">
+						<% if other_availability_json.present? %>
+							<% other_availability_json.each do |form| %>
+								<% f = JSON.parse(form) %>
+								<div class="other-form">
+									<span class="other-form-title">
+										<%= link_to f["title"], "/catalog/#{f["bibid"]}", { "aria-label": "#{f["title"]}, bib ID #{f["bibid"]}" } %>
+									</span>
+									<% formats = f["format"].split(",") %>
+									<% formats.each do |format| %>
+										<span class="other-form-format">
+											<i class="fa fa-<%= formats_icon_mapping(format) %>" aria-hidden="true"></i><%= format %>
+										</span>
+									<% end %>
+									<% if f["pub_date"].present? %>
+										<span class="other-form-date"><%= f["pub_date"] %></span>
+									<% end %>
+									<% if f["language"].present? %>
+										<span class="other-form-language"><%= f["language"] %></span>
+									<% end %>
+									<% if f["edition"].present? %>
+										<span class="other-form-edition"><%= f["edition"] %></span>
+									<% end %>
+									<% if f["sites"].present? %>
+										<span class="other-form-online">
+											<span class="status-online online-label">Online</span>
+										</span>
+									<% end %>
+									<% if f["libraries"].present? %>
+										<span class="at-library-label">At the Library</span>
+									<% end %>
+								</div>
+								<%# end other-form %>
+							<% end %>
+						<% end %>
+						<% if workid_display.present? %>
+							<p><%= link_to "See all forms of this work", '/?f[workid_facet][]=' + workid_facet[0] %></p>
+						<% end %>
+					</div>
 				</div>
 			<% end %>
-
-	      <%  summary_holdings = '' %>
-	      <% if is_online?(@document) %>
-	        <div class="holdings-online">
-	        	<div class="online-label">
-	            <i class="fa fa-check" aria-hidden="true"></i>Online
-	        	</div>
-	        <ul class="list-unstyled">
-	         <% if @document["holdings_json"].present? %>
-	         <%# holdings = JSON.parse(@document['holdings_record_display'][0]) %>
-	         <%# getID = holdings["id"] %>
-                            <%#= JSON.parse(@document["holdings_json"])[getID]["holdings"].inspect %>
-             <% holdings_json = JSON.parse(holdings_json) %>
-                            <%#= JSON.parse(@document["holdings_json"]).inspect %>
-                            <%#= holdings_json[getID]["links"].inspect %>
-                            <%#= holdings_json[getID]["links"][0]["description"].inspect %>
-                            <%#= holdings.inspect %>
-              <% holdings_json.each do |key, value|  %>
-         		<% if holdings_json[key]["active"].nil? or holdings_json[key]["active"] == true && (key != "1" && key != "2")%>
-              	  <%#= value["online"].inspect %>
-              	  <% if value["online"] == true and !value["links"].nil? %>
-               	    <%#=  value.inspect %>
-               		<% value["links"].each do | link | %>
-                  	  <%#=  link["url"].inspect %>
-                  	  <%#= link["description"].inspect %>
-                  	  <% if link["description"].present? %>
-                  	    <% label = link["description"] %>
-                  	  <% else %>
-                  	    <% label = t('blacklight.url.message')  %>
-                  	  <% end %>
-	                  <li>
-	                    <div class="online-link">
-                        <% if label.include?("Temporary Access") %>
-                          <% label = "Information for users about temporary access." %>
-                        <% end %>
-	                    <%= link_to(process_online_title(label), link["url"].html_safe, {:class => 'online-access', :onclick => "javascript:_paq.push(['trackEvent', 'itemView', 'outlink']);"}) %>
-	                    <div class="message">
-	                      <%= summary_holdings.html_safe %>
-	                    </div>
-	                    <div class="message">
-	                      <%#= key.inspect %>
-	                      <% if key.present? %>
-	                        <%#= value.inspect %>
-	                        <% holdings = value %>
-	                        <% getID = key %>
-	                        <% if !value['holdings'].nil? %>
-	                          <% sizer = value['holdings'].size %>
-	                          <% if sizer != 1 %>
-	                            Library has:<br/> <%= value['holdings'].join('<br>').html_safe %>
-	                          <% else %>
-	                            Library has: <%= value['holdings'][0].html_safe %>
-	                          <% end %>
-	                        <% end %>
-	                        <% if !value['indexes'].nil? %>
-	                          <% sizer = value['indexes'].size %>
-	                          <% if sizer != 0 %>
-	                            <br>Indexes: <%= value['indexes'].join('<br>').html_safe %>
-	                          <% elsif value['indexes'][0].present? %>
-	                            Indexes: <%= value['indexes'][0].html_safe %>
-	                          <% end %>
-	                        <% end %>
-	                        <% if !value['notes'].nil? %>
-	                          <% sizer = value['notes'].size %>
-	                          <% if sizer != 0 %>
-	                            <br>Notes: <%= value['notes'].join('<br>').html_safe %>
-	                          <% elsif value['notes'][0].present? %>
-	                            Notes: <%= value['notes'][0].html_safe %>
-	                          <% end %>
-	                        <% end %>
-	                        <% if !value['supplements'].nil? %>
-	                          <% sizer = value['supplements'].size %>
-	                          <% if sizer != 0 %>
-	                            <br>Supplements: <%= value['supplements'].join('<br>').html_safe %>
-	                          <% elsif value['supplements'][0].present? %>
-	                            Supplements: <%= value['supplements'][0].html_safe %>
-	                          <% end %>
-	                        <% end %>
-	                      <% end %>
-                          </div>
-	                      <%#= @document['title_display'].inspect %>
-                          <% parsed_json = JSON.parse(@document['url_access_json'][0]) %>
-                          <%#= parsed_json['titleid'] %>
-                          <%#= @document['id'] %>
-                          <% if parsed_json['titleid'].present? %>
- 	                        <span class="terms-of-use">
- 	                        <%#= @document.inspect %>
-	                          <span class="fa fa-chevron-right" aria-hidden="true"></span>
-                              <a href="/catalog/new_tou/<%= parsed_json['titleid'] %>/<%= @document['id']	%> ">Terms of use</a>
- 		                    </span>
-                          <% else %>
-	                        <% if link["dbcode"].present? && link["providercode"].present? %>
-	                          <span class="terms-of-use">
-	                            <span class="fa fa-chevron-right" aria-hidden="true"></span>
-		                        <a href="/catalog/tou/<%= @document[:id] %>/<%= link["providercode"] %>/<%= link["dbcode"] %>">Terms of use</a>
-		                        <%#= holdings_json.inspect  %>
-		                         <% if restrictions_display.present? %>
-		                       	   </div>
-		                       	 <% end %>
-						  		 <% if !restrictions_display.present? %>
-						  		   <span class="access-restriction">
-	          			  		   <% if !holdings_json.nil? %>
-	                                 <% holdings_json.each do |k,holding| %>
-
-	                                   <% if !holdings_json[k]['links'].nil? %>
-
-	               		  			   <% if !holdings_json[k]['links'][0]['users'].nil?  and holdings_json[k]['links'][0]['users'] != 'nil'%>
-	                                     <%#= holdings_json[k]['links'][0]['users'].inspect %>
-	              		  				 <%# Limiteds to <%= holdings_json[k]['links'][0]['users'].inspect '\%\>  simultaneous users %>
-	               		  			   <% end %>
-
-	               		  			  <% end %>
-
-	            		  			 <% end %>
-	           			  		   <% end %>
-	           			  		   </span>
-	           			  		 <% end %>
-	                        <% else %>
-                            <% end %>
-                          <% end %>
-	                      <% if !restrictions_display.present? %>
-                            </div>
-                          <% end %>
-	                      </li>
-	              <%# end %>
-
-
-
-
-              <% end %>
-
-                <% end %>
-                <% end %>
-
-	            <% end %>
-	           <% end %>
-	          </ul>
-	        </div>
-	      <%end %>
-            <%# online-holdings %>
-
-	      <%# end %>
-	      <%# end online %>
-	      <%# print holdings %>
-	      <!-- solr verion of holdings -->
-	      <div class="holdings">
-	        <%#= @document.inspect %>
-	        <% if !@document['holdings_json'].nil? %>
-	          <% holdings = JSON.parse(@document['holdings_json']) %>
-	          <%#= JSON.parse(holdings).to_s.inspect %>
-	          <%#= getID.inspect %>
-	          <%#= holdings[getID].inspect %>
-	          <%#= holdings.inspect %>
-	          <% circulating_items = [] %>
-	          <% rare_items = [] %>
-	          <% online_items = [] %>
-	          <% holdings.each do |k,holding| %>
-	          <%#= holdings[k]["active"].inspect %>
-	          <% if !holding["restrictions"].nil? %>
-	          <%   holdings_restrictions = holding["restrictions"][0] %>
-	          <% end %>
-	          <% if !holding['links'].nil? and holding['links'][0]['users'].present?  %>
-	          <span class="access-restriction">
-	            <h3>Restrictions</h3>
-	            Limited to <%= holding['links'][0]['users'].inspect %> simultaneous users
-	          </span>
-	          <% end %>
-       			<% if holdings[k]["active"].nil? or holdings[k]["active"] == true %>
-
-	             		<% if holding["location"].present? %>
-	                		<% if holding["location"]["name"].include?('Rare') || holding["location"]["name"].include?('Kheel') %>
-	                   			<% rare_items << holding %>
-	                		<% else %>
-	                		   <% circulating_items << holding %>
-	                		<% end %>
-	             		<% elsif holding["online"].present? %>
-	                		<% online_items << holding %>
-	             		<% end %>
-                  <% end %>
-	          <% end %>
-	          <% if !circulating_items.blank? %>
-	             <% items = circulating_items.sort_by { |e| e["location"]["name"]  } %>
-	             <% group = "Circulating" %>
-	             <%= render 'holdings_group',:items => items, :group => group %>
-	          <% end %>
-	          <% if !rare_items.blank? %>
-	             <% items = rare_items.sort_by { |e| e["location"]["name"]  } %>
-	             <% group = "Rare" %>
-	             <% if circulating_items.present? %>
-	                <h3>Rare Items</h3>
-	             <% end %>
-	             <%= render 'holdings_group',:items => items, :group => group %>
-	          <% end %>
-	        <% end %>
-	      </div>
-	      <%# access restrictions %>
-	      <% if holdings_restrictions != "" %>
-	        <span class="access-restriction">
-	         <h3>Restrictions</h3>
-	         <%= holdings_restrictions %>
-	         </span>
-	      <% end %>
-	      <% if restrictions_display.present? %>
-
-	        <span class="access-restriction">
-	          <h3>Restrictions</h3>
-	          <%= restrictions_display.map(&:inspect).join('; ').gsub('\\"', '') %>
-	          <% if !@document['holdings_json'].nil? %>
-	            <% holdings = JSON.parse(@document['holdings_json']) %>
-	            <% holdings.each do |k,holding| %>
-	               <% if !holdings[k]['links'].nil? and !holdings[k]['links'][0]['users'].nil? %>
-	                Limited to <%= holdings[k]['links'][0]['users'].inspect  %> simultaneous users
-	               <% end %>
-	            <% end %>
-	           <% end %>
-	        </span>
-	      <% end %>
-	      <%# end availability %>
-	    </div>
-	  </div>
-	  <%# other forms %>
-	  <% if  other_availability_json.present? || workid_display.present?   %>
-	    <div class="availability card ">
-	      <div class="card-header">
-	        Other forms of this work
-	      </div>
-	      <div class="card-block">
-	        <% if  other_availability_json.present?  %>
-	          <% other_availability_json.each do |form| %>
-	            <% f = JSON.parse(form) %>
-	            <div class="other-form">
-	              <span class="other-form-title">
-	                <%= link_to f["title"], "/catalog/#{f["bibid"]}", { "aria-label": "#{f["title"]}, bib ID #{f["bibid"]}" } %>
-	              </span>
-	              <% formats = f["format"].split(",") %>
-	                <% formats.each do |format| %>
-	                  <span class="other-form-format">
-	                    <i class="fa fa-<%= formats_icon_mapping(format) %>" aria-hidden="true"></i><%= format %>
-	                  </span>
-	                <% end %>
-	                <% if f["pub_date"].present? %>
-	                  <span class="other-form-date"><%= f["pub_date"] %></span>
-	                <% end %>
-	                <% if f["language"].present? %>
-	                  <span class="other-form-language"><%= f["language"] %></span>
-	                <% end %>
-	                <% if f["edition"].present? %>
-	                  <span class="other-form-edition"><%= f["edition"] %></span>
-	                <% end %>
-	                <% if f["sites"].present? %>
-	                  <span class="other-form-online">
-	                    <span class="status-online online-label">Online</span>
-	                  </span>
-	                <% end %>
-	                <% if f["libraries"].present? %>
-	                  <span class="at-library-label">At the Library</span>
-	                <% end %>
-	                </div>
-	                <%# end other-form %><% end %>
-	              <% end %>
-	              <% if workid_display.present?  %>
-	                <p><%= link_to "See all forms of this work",'/?f[workid_facet][]=' + workid_facet[0] %></p>
-	              <% end %>
-	            </div>
-	      </div>
-	    <% end %>
-	  </div>
-	  <%# end col-md-4 %>
-	  <div class="col-md-8 order-md-4">
-	    <div class="float-sm-right item-cover">
-				<% if @document["format_main_facet"] == "Musical Recording" && @discogs_image_url.present?%>
-					<%= format_discogs_image(@discogs_image_url)%>
+		</div>
+		<%# end col-md-4 %>
+		<div class="col-md-8 order-md-4">
+			<div class="float-sm-right item-cover">
+				<% if @document["format_main_facet"] == "Musical Recording" && @discogs_image_url.present? %>
+					<%= format_discogs_image(@discogs_image_url) %>
 				<% end %>
 				<% unless @document["no_google_img_b"] %>
 					<div class="bookcover d-none d-sm-inline" id="OCLC:<%= bookcover_oclc(@document) %>" data-oclc="<%= bookcover_oclc(@document) %>"></div>
 				<% end %>
 			</div>
-	    <%# item-cover %>
-	    <%= render_document_partial @document, :show %>
+			<%# item-cover %>
+			<%= render_document_partial @document, :show %>
 			<% if @document["format_main_facet"] == "Musical Recording" %>
-		   <div id="discogs_disclaimer"></div>
+				<div id="discogs_disclaimer"></div>
 			<% end %>
-		<!--Adding Wikidata sourcing -->
-		<div id="wikidata_source"></div>
+			<!--Adding Wikidata sourcing -->
+			<div id="wikidata_source"></div>
 
 			<%# DISCOVERYACCESS-6275 %>
 			<% unless @document["no_syndetics_b"] %>
 				<% if ENV['SYNDETICS_UNBOUND_ENABLED'].present? && ENV['SYNDETICS_UNBOUND_ENABLED'] == "1" %>
-				<div id="syndetics_unbound"></div>
-				<script src="https://unbound.syndetics.com/syndeticsunbound/connector/initiator.php?a_id=1624&i_id=2636"
-								type="text/javascript"></script>
+					<div id="syndetics_unbound"></div>
+					<script src="https://unbound.syndetics.com/syndeticsunbound/connector/initiator.php?a_id=1624&i_id=2636"
+									type="text/javascript"></script>
 				<% end %>
 			<% end %>
 
-	    <%= render :partial => 'catalog/call_number_browse_links' %>
-	    <%# browse-call-number %>
+			<%= render :partial => 'catalog/call_number_browse_links' %>
+			<%# browse-call-number %>
 		</div>
-	  </div>
-	  <%# col-sm-8 %>
+		<%# col-sm-8 %>
     </div>
     <%# row %>
   </div>


### PR DESCRIPTION
This addresses two accessibility issues:

- [DACCESS-899](https://culibrary.atlassian.net/browse/DACCESS-899) [aria attribute does not exist](https://my2.siteimprove.com/Accessibility/1172976/NextGen/Issue/1?ruleId=20&pageSegments=&issueKind=1&tagFilterType=2&conformance=) - typo in terms of use aria-hidden attribute
- [DACCESS-897](https://culibrary.atlassian.net/browse/DACCESS-897): content missing after heading - we are using H3 for the subtitle and responsibility (author) which is not appropriate use of headings
- Also changes fixed font sizes in item view sass

[DACCESS-899]: https://culibrary.atlassian.net/browse/DACCESS-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-897]: https://culibrary.atlassian.net/browse/DACCESS-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ