### PR TITLE
DACCESS-899: accessibility fixes

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_databases.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_databases.scss
@@ -130,6 +130,7 @@
 
 .z-note {
 	font-style: italic;
+	font-size: 0.9rem;
 }
 .page-title {
 	h2 { margin-top: 0; }

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_item-record.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_item-record.scss
@@ -3,22 +3,21 @@
 .return-link {
 	display: inline-block;
 	margin-bottom: .6em;
-	font-size: 12px;
+	font-size: .9rem;
 }
 
 .document-header {
 	margin-bottom: 1.5em;
 }
 
-h3.subtitle,
-h3.responsibility {
-	font-size: 16px;
+.subtitle,
+.responsibility {
 	font-weight: normal;
 	line-height: 1.2em;
 	margin-bottom: 1em;
 	margin-top: 0;
 }
-h3.responsibility {
+.responsibility {
 	color: $medium-gray;
 }
 

--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -158,13 +158,13 @@
                           <% if parsed_json['titleid'].present? %>
  	                        <span class="terms-of-use">
  	                        <%#= @document.inspect %>
-	                          <span class="fa fa-chevron-right" aria-hiden="true"></span>
+	                          <span class="fa fa-chevron-right" aria-hidden="true"></span>
                               <a href="/catalog/new_tou/<%= parsed_json['titleid'] %>/<%= @document['id']	%> ">Terms of use</a>
  		                    </span>
                           <% else %>
 	                        <% if link["dbcode"].present? && link["providercode"].present? %>
 	                          <span class="terms-of-use">
-	                            <span class="fa fa-chevron-right" aria-hiden="true"></span>
+	                            <span class="fa fa-chevron-right" aria-hidden="true"></span>
 		                        <a href="/catalog/tou/<%= @document[:id] %>/<%= link["providercode"] %>/<%= link["dbcode"] %>">Terms of use</a>
 		                        <%#= holdings_json.inspect  %>
 		                         <% if restrictions_display.present? %>

--- a/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_metadata.html.erb
@@ -29,10 +29,10 @@
     <h2><%= @title %></h2>
   <% end %>
   <% if @subtitle.present? %>
-    <h3 class="subtitle"><%= @subtitle %></h3>
+    <div class="subtitle"><%= @subtitle %></div>
   <% end %>
   <% if responsibility.present? %>
-    <h3 class="responsibility"><%= responsibility.join('; ') %></h3>
+    <div class="responsibility"><%= responsibility.join('; ') %></div>
   <% end %>
   </div>
   <div class="row">

--- a/blacklight-cornell/app/views/databases/_database.html.erb
+++ b/blacklight-cornell/app/views/databases/_database.html.erb
@@ -35,12 +35,12 @@
           <% end %>
         </h3>
         <div class="description">
-          <p class="z-note">
+          <div class="z-note mb-3">
             <% znote = access_z_note(data) %>
             <% if znote.present? %>
              <%= znote %>
             <% end %>
-          </p>
+          </div>
           <p>
             <% if data["summary_display"].present? %>
               <%= data["summary_display"][0] %>


### PR DESCRIPTION
[DACCESS-899](https://culibrary.atlassian.net/browse/DACCESS-899)

This PR includes:

- fix typo in `aria-hidden` attribute in availability box TOU link icon
- siteimprove triggers an error because italics are applied to a paragraph in databases. the content is generally brief so i changed this to a `div` but kept the italics.
- content missing after heading - changed `H3` to `div` for subtitle and author on the item view display, as we were not using headings properly in these instances

[DACCESS-899]: https://culibrary.atlassian.net/browse/DACCESS-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ