### PR TITLE
DACCESS-894: change font size to relative

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss
@@ -151,7 +151,7 @@ h3 { font-size: 20px; line-height: 1.5em;}
 // ----------------------
 .toplink {
 	margin: 1em 0;
-	font-size: 12px !important;
+	font-size: .9rem !important;
 	text-align: right;
 }
 

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_databases.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_databases.scss
@@ -11,21 +11,6 @@
 		background: $light-tan;			
 	}
 }
-.databases-search {
-	.form-group { padding-left: 0; }
-
-	p {
-		font-size: 14px;
-	}
-	h2 {
-		font-size: 20px;
-		line-height: 1.1em
-	}
-
-	form {
-		margin-bottom:0px;
-	}
-}
 .blacklight-database-name {
 	padding-top: 15px;
 	h3 { margin-bottom: 20px; }
@@ -36,13 +21,6 @@
 	}
 	td,th {
 		font-size:14px;
-	}
-	.description {
-		p { 
-			font-size: 14px;
-			line-height: 1.6em;
-		}
-
 	}
 	.blacklight-title_display {
 		margin: 0 0 .5em;
@@ -121,7 +99,7 @@
 }
 .terms {
 	color: $medium-gray;
-	font-size: 12px;
+	font-size: .9rem;
 	.divider { 
 		color: #ccc;
 		margin: 0 3px;
@@ -156,6 +134,6 @@
 .resource {
 	margin-top: 0;
 	.document-data {
-		p { font-size: 14px; }
+		p { font-size: .9rem; }
 	}
 }

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_digitalcollections.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_digitalcollections.scss
@@ -3,21 +3,10 @@
 
 .digitalcollections-search {
 	margin-top: 20px;
-	h2 {
-		font-weight: normal;
-		color: $dark-gray;
-		line-height: 1.1em
-	}
-	.form-group { padding-left: 0; }
-	p {
-		font-size: 14px;
-	}
-	form {
-		margin-bottom:0px;
-	}
 }
 
 .digital-collections {
+	margin-top: 1.5rem;
 	.document {
 		border-bottom: 1px solid $light-tan;
 	}
@@ -31,25 +20,11 @@
 		width: 100%;
 		padding: 0 0 15px 0;
 	}
-	td,th {
-		font-size:14px;
-	}
-	.description {
-		p { 
-			font-size: 14px;
-			line-height: 1.6em;
-		}
-
-	}
 	.blacklight-title_display {
 		margin: 0 0 .5em;
 		font-weight: normal;
 		line-height: 1.2em;
-		font-size: 20px;
-		i { 
-			font-size: 12px;
-			margin-left: 5px;
-		}
+		font-size: 1.4rem;
 		a {
 			margin-left: 0;
 		}
@@ -62,7 +37,7 @@
 .catalog-link {
 	list-style: none;
 	margin: 0;
-	font-size: 12px;
+	font-size: .9rem;
 	li {
 		float: left;
 		border-left: 1px solid $databases-light-gray;

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_footer.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_footer.scss
@@ -1,7 +1,7 @@
 footer {
 	border-top: 1px solid #ddd;
 	p {
-		font-size: 12px;
+		font-size: .9rem;
 	}
 	a, a:hover {
 		color: $dark-gray;
@@ -58,7 +58,7 @@ footer {
 footer {
 	h3 {
 		text-transform: uppercase;
-		font-size: 12px;
+		font-size: .9rem;
 		margin: 2em 0 0 0;
 		color: $dark-gray;
 	}
@@ -79,15 +79,10 @@ footer {
 	.footer-nav {
 		li {
 			border-left: 1px solid $light-gray;
-			font-size: 13px;
+			font-size: .9rem;
 		}
 		li:first-child {
 			border-left: 0;
-		}
-	}
-	footer {
-		p {
-			font-size: 13px;
 		}
 	}
 }

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_search-results.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_search-results.scss
@@ -19,8 +19,8 @@ body.book_bags-index #documents .document {
 .blacklight-title_display {
 	margin: 0 0 .5em 0;
 	font-weight: normal;
-	line-height: 1.5em;
-	font-size: 20px;
+	// line-height: 1.5em;
+	font-size: 1.4rem;
 	a {
 		margin-left: .25em;
 	}


### PR DESCRIPTION
[DACCESS-894](https://culibrary.atlassian.net/browse/DACCESS-894)
 
This addresses a AAA [SiteImprove error: Font size is fixed](https://my2.siteimprove.com/Accessibility/1172976/NextGen/Issue/1?ruleId=74&pageSegments=&issueKind=1&exceptTags=1,2&conformance=).

Areas affected include:

- Databases
- Digital Collections
- Terms of Use
- Footer

Also removed styles that we don't appear to need.

We originally wrote these stylesheets in 2012-14. There may be other instances with fixed font sizes, but wanted to focus on the ones called out by SiteImprove in order to clear this error. While it's AAA and we are not required to hit AAA yet, clearing this error will give us 1.58 points on our score and it seems worth updating.

We will address other fixed font sizes as needed, and definitely review refactor when we upgrade Blacklight.

[DACCESS-894]: https://culibrary.atlassian.net/browse/DACCESS-894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ