### PR TITLE
DACCESS-824 - Render DocumentMetadataComponent instead of deprecated document_show_fields

### DIFF
--- a/blacklight-cornell/app/components/blacklight/metadata_field_component.html.erb
+++ b/blacklight-cornell/app/components/blacklight/metadata_field_component.html.erb
@@ -1,0 +1,9 @@
+<%# Overrides Blacklight::MetadataFieldComponent to set default label and value classes %>
+<%= render(@layout.new(field: @field, label_class: 'col-sm-3', value_class: 'col-sm-9')) do |component| %>
+  <% component.with_label do %>
+    <%= label %>
+  <% end %>
+  <% component.with_value do %>
+    <%= @field.render %>
+  <% end %>
+<% end %>

--- a/blacklight-cornell/app/controllers/catalog_controller.rb
+++ b/blacklight-cornell/app/controllers/catalog_controller.rb
@@ -336,8 +336,8 @@ class CatalogController < ApplicationController
     # -- title_vern_display
     # -- subtitle_display
     # -- subtitle_vern_display
-    config.add_show_field 'title_uniform_display', :label => 'Uniform title'
-    config.add_show_field 'author_json', :label => 'Author, etc.'
+    config.add_show_field 'title_uniform_display', label: 'Uniform title', helper_method: :render_clickable_document_show_field_value
+    config.add_show_field 'author_json', label: 'Author, etc.', helper_method: :render_author
     config.add_show_field 'format', :label => 'Format', :helper_method => :render_show_format_value, separator_options: { words_connector: '<br />', last_word_connector: '<br />' }
     config.add_show_field 'language_display', :label => 'Language'
     config.add_show_field 'edition_display', :label => 'Edition'
@@ -351,20 +351,20 @@ class CatalogController < ApplicationController
     config.add_show_field 'cite_as_display', :label => 'Cite as'
     config.add_show_field 'historical_note_display', :label => 'Biographical/ Historical note'
     config.add_show_field 'finding_aids_display', :label => 'Finding aid'
-    config.add_show_field 'subject_json', :label => 'Subject'
+    config.add_show_field 'subject_json', label: 'Subject', helper_method: :render_clickable_document_show_field_value
     config.add_show_field 'keyword_display', :label => 'Keyword'
     config.add_show_field 'summary_display', :label => 'Summary', helper_method: :html_safe
     config.add_show_field 'description_display', :label => 'Description', helper_method: :html_safe
     config.add_show_field 'issn_display', :label => 'ISSN'
     config.add_show_field 'isbn_display', :label => 'ISBN'
     config.add_show_field 'frequency_display', :label => 'Frequency'
-    config.add_show_field 'author_addl_json', :label => 'Other contributor'
+    config.add_show_field 'author_addl_json', label: 'Other contributor', helper_method: :render_clickable_document_show_field_value
     config.add_show_field 'contents_display', :label => 'Table of contents', helper_method: :contents_list
     config.add_show_field 'partial_contents_display', :label => 'Partial table of contents'
     config.add_show_field 'title_other_display', :label => 'Other title'
-    config.add_show_field 'included_work_display', :label => 'Included work'
-    config.add_show_field 'related_work_display', :label => 'Related Work'
-    config.add_show_field 'title_series_cts', :label => 'Series'
+    config.add_show_field 'included_work_display', label: 'Included work', helper_method: :render_clickable_document_show_field_value
+    config.add_show_field 'related_work_display', label: 'Related Work', helper_method: :render_clickable_document_show_field_value
+    config.add_show_field 'title_series_cts', label: 'Series', helper_method: :render_clickable_document_show_field_value
     config.add_show_field 'continues_display', :label => 'Continues'
     config.add_show_field 'continues_in_part_display', :label => 'Continues in part'
     config.add_show_field 'supersedes_display', :label => 'Supersedes'
@@ -399,7 +399,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'indexes_display', :label => 'Indexes'
     config.add_show_field 'donor_display', :label => 'Donor'
     config.add_show_field 'former_owner_display', :label => 'Former Owner'
-    config.add_show_field 'url_other_display', :label => 'Other online content'
+    config.add_show_field 'url_other_display', label: 'Other online content', helper_method: :render_display_link
     config.add_show_field 'works_about_display', :label => 'Works about'
     config.add_show_field 'awards_display', :label => 'Awards'
     # config.add_show_field 'holdings_json', :label => 'Holdings'

--- a/blacklight-cornell/app/helpers/display_helper.rb
+++ b/blacklight-cornell/app/helpers/display_helper.rb
@@ -302,7 +302,6 @@ module DisplayHelper
   end
 
   def render_clickable_document_show_field_value args
-    dp = Blacklight::DocumentPresenter.new(nil, nil, nil)
     value = args[:value]
     value ||= args[:document].fetch(args[:field], :sep => nil) if args[:document] and args[:field]
     args[:sep] ||= blacklight_config.multiline_display_fields[args[:field]] || field_value_separator;
@@ -507,10 +506,6 @@ module DisplayHelper
     end
   end
 
-  def display_link?(field)
-    blacklight_config.display_link[field] != nil
-  end
-
   def is_online? document
     (document['online'].present? && document['online'].include?('Online')) ? true : false
   end
@@ -546,6 +541,32 @@ module DisplayHelper
       ic = icon_mapping
     end
     ic
+  end
+
+  def render_author(show_field)
+    document = show_field[:document]
+    field = show_field[:field]
+    value = show_field[:value]
+
+    author_link = render_clickable_document_show_field_value(document:, field:)
+    browse_paths = value.map do |authority|
+      heading = JSON.parse(authority)
+      if heading['authorizedForm']
+        type = heading['type']
+        search = heading['search2'].present? ? heading['search2'] : heading['search1']
+
+        link_to(t('blacklight.related_auth.author'),
+          browse_info_path(authq: search.gsub("&", "%26"),
+                           bib: document.id,
+                           browse_type: 'Author',
+                           headingtype: type),
+          class: 'info-button btn btn-xs btn-outline-secondary',
+          'aria-label': "Author info for #{search}",
+          role: 'button',
+          onclick: "javascript:_paq.push(['trackEvent', 'itemView', 'author-info']);")
+      end
+    end
+    author_link + browse_paths.join(' ').html_safe
   end
 
   def render_show_format_value field

--- a/blacklight-cornell/app/views/catalog/_show_default.html.erb
+++ b/blacklight-cornell/app/views/catalog/_show_default.html.erb
@@ -1,47 +1,7 @@
 <%# default partial to display solr document fields in catalog show view -%>
-<dl class="row" id="itemDetails">
-  <% document_show_fields(document).each do |solr_fname, field| -%>
-    <% if document.has? solr_fname  -%>
-	    <dt class="blacklight-<%= solr_fname.parameterize %> col-sm-3"><%= render_document_show_field_label document, :field => solr_fname %></dt>
-      <dd class="blacklight-<%= solr_fname.parameterize %> col-sm-9">
-       
-        <% if  solr_fname == 'author_json' -%>
-          <%= render_clickable_document_show_field_value :document => document, :field => solr_fname %>
-          <% authname = field_value solr_fname %>
-          <% document['author_json'].each do |authority| %>
-          <% heading = JSON.parse(authority) %>
-          <% if heading["authorizedForm"] == true %> 
-          <% type = heading['type']  %>
-          <% if heading['search2'].present?  %>
-          <% search = heading['search2'] %>
-          <% else search = heading['search1']  %>
-          <% end %>
-
-          <%= link_to(t('blacklight.related_auth.author'),
-                      browse_info_path(authq: search.gsub("&", "%26"),
-                                       bib: document.id,
-                                       browse_type: 'Author',
-                                       headingtype: type),
-                      class: 'info-button btn btn-xs btn-outline-secondary',
-                      'aria-label': "Author info for #{search}",
-                      role: 'button',
-                      onclick: "javascript:_paq.push(['trackEvent', 'itemView', 'author-info']);") %>
-          <% end %>
-          <% end %>
-       
-          <% elsif display_link? solr_fname -%>   
-           <%= render_display_link :document => document, :field => solr_fname %>
-
-        <% elsif display_clickable? solr_fname -%>
-          <%= render_clickable_document_show_field_value :document => document, :field => solr_fname %>
-        
-        <% else -%>
-          <%= field_value solr_fname %>
-        <% end -%>
-      </dd>
-    <% end -%>
-  <% end -%>
-</dl>
+<%= render Blacklight::DocumentMetadataComponent.new(fields: document_presenter(@document).field_presenters,
+                                                     classes: ['row'],
+                                                     id: 'itemDetails') %>
 
 <%# Empty div with data-attributes for javascript %>
 <%= content_tag :div, nil, id: 'work', class: 'd-none', data: { heading: document['authortitle_facet'] } %>


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
Addresses blacklight 8 deprecation warnings related to `document_show_fields` and `render_document_show_field_label` by rendering blacklight's MetadataFieldComponent and moving per-field display logic to helper_method options in CatalogController. Also overrides MetadataFieldComponent html to use our overridden bootstrap classes.


<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
- [DACCESS-824](https://culibrary.atlassian.net/browse/DACCESS-824)
- [DACCESS-825](https://culibrary.atlassian.net/browse/DACCESS-825)



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [ ] 🐛 `bug` — Bug fix
- [x] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
<!--
    Instructions so a reviewer can verify this PR locally.
    Include edge cases, test data, URLs, Staging or Integration environments used that may be helpful.
-->

Go to any catalog record view and make sure nothing looks different than before.


<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-824]: https://culibrary.atlassian.net/browse/DACCESS-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-825]: https://culibrary.atlassian.net/browse/DACCESS-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ