### PR TITLE
fix: added  Devise::Test::ControllerHelpers to fix warden errors

### DIFF
--- a/blacklight-cornell/spec/rails_helper.rb
+++ b/blacklight-cornell/spec/rails_helper.rb
@@ -79,6 +79,7 @@ RSpec.configure do |config|
   # end
 
   # Enable ViewComponent test helpers
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponentTestHelpers, type: :component
 end


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
<!-- Briefly describe what this PR does and why -->
This change enables `Devise::Test::ControllerHelpers` for `type: :controller` specs in `spec/rails_helper.rb`.

`ApplicationController` now runs `before_action :initialize_bookbag_state`, and that callback starts with return unless `current_user`. In controller specs, the full middleware stack is not executed, so Warden is not present by default. Devise’s `current_user` depends on `request.env['warden']`, which caused `Devise::MissingWarden` before the action under test could run.

Including `Devise::Test::ControllerHelpers` injects the Warden proxy into controller-test requests, so `current_user` can be evaluated correctly. That restores expected controller-spec behavior and prevents unrelated specs from failing when `initialize_bookbag_state` runs.


<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- Related to: [DACCESS-840](https://culibrary.atlassian.net/browse/DACCESS-840) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [x] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
<!--
    Instructions so a reviewer can verify this PR locally.
    Include edge cases, test data, URLs, Staging or Integration environments used that may be helpful.
-->
- When `bundle exec rspec`  is executed all rspec tests should pass now



<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ