### PR TITLE
DACCESS-882 Move extra query sanitization from BlacklightCornell::CornellCatalog to SearchBuilder

### DIFF
--- a/blacklight-cornell/app/models/search_builder.rb
+++ b/blacklight-cornell/app/models/search_builder.rb
@@ -293,29 +293,21 @@ class SearchBuilder < Blacklight::SearchBuilder
     # Replace left and right quotation marks with regular quotes
     query.gsub!(/[”“]/, '"')
 
+    # Replace double-encoded space
+    query.gsub!('%2520',' ')
+
     # Handle unpaired quotes
     # If the first character is an unpaired quotation mark, close quotation
     query = query + '"' if query.count('"') == 1 && query[0] == '"'        
     # Remove unpaired quotes
     query.gsub!('"', '') if query.count('"') % 2 == 1
-
-    # Replace double-encoded space
-    query.gsub!('%2520',' ') if query.include?('%2520')
-
-    # Remove slashes
-    query.gsub!('%2F','') if query.include?('%2F')
-    query.gsub!('/','') if query.include?('/')
-    while (query[-1] == "\\") do
-      query[-1] = ""
-      query.rstrip!
-    end
     
-    # Remove: parentheses, brackets. Escape: colons, plus signs, minus signs/dashes
+    # Remove: parentheses, brackets, slashes (both encoded and unencoded), trailing backslashes. Escape: colons, plus signs, minus signs/dashes
     # From: https://solr.apache.org/guide/8_8/the-dismax-query-parser.html
     #       The DisMax query parser supports an extremely simplified subset of the Lucene QueryParser syntax.
     #       As in Lucene, quotes can be used to group phrases, and +/- can be used to denote mandatory and optional clauses.
     #       All other Lucene query parser special characters (except AND and OR) are escaped to simplify the user experience.
-    query.gsub(/[\[\]\(\):+-]/, ':' => '\:', '+' => '\+', '-' => '\-')
+    query.gsub(/[\[\]\(\):+\-\/]|%2F|\\+\z/, ':' => '\:', '+' => '\+', '-' => '\-')
   end
 
   # Pair 2 queries with booleans, wrap each pair in parentheses

--- a/blacklight-cornell/app/models/search_builder.rb
+++ b/blacklight-cornell/app/models/search_builder.rb
@@ -286,7 +286,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     params[:q_row].map { |query| clean_q(query) }
   end
 
-  # Handle special characters and unpaired quotation marks in q_row
+  # Handle special characters and unpaired quotation marks in query
   def clean_q(query)
     query.strip!
 
@@ -299,6 +299,17 @@ class SearchBuilder < Blacklight::SearchBuilder
     # Remove unpaired quotes
     query.gsub!('"', '') if query.count('"') % 2 == 1
 
+    # Replace double-encoded space
+    query.gsub!('%2520',' ') if query.include?('%2520')
+
+    # Remove slashes
+    query.gsub!('%2F','') if query.include?('%2F')
+    query.gsub!('/','') if query.include?('/')
+    while (query[-1] == "\\") do
+      query[-1] = ""
+      query.rstrip!
+    end
+    
     # Remove: parentheses, brackets. Escape: colons, plus signs, minus signs/dashes
     # From: https://solr.apache.org/guide/8_8/the-dismax-query-parser.html
     #       The DisMax query parser supports an extremely simplified subset of the Lucene QueryParser syntax.

--- a/blacklight-cornell/config/locales/blacklight.en.yml
+++ b/blacklight-cornell/config/locales/blacklight.en.yml
@@ -177,7 +177,6 @@ en:
       errors:
         request_error: "Sorry, I don't understand your search."
         invalid_solr_id: "Sorry, you have requested a record that doesn't exist."
-        invalid_query: "Sorry, your search could not be executed."
         publication_year_range:
           general: "Publication Year: Please enter a valid date range."
           begin: "Publication Year: Please enter a start date."

--- a/blacklight-cornell/config/locales/blacklight.en.yml
+++ b/blacklight-cornell/config/locales/blacklight.en.yml
@@ -177,6 +177,7 @@ en:
       errors:
         request_error: "Sorry, I don't understand your search."
         invalid_solr_id: "Sorry, you have requested a record that doesn't exist."
+        invalid_query: "Sorry, your search could not be executed."
         publication_year_range:
           general: "Publication Year: Please enter a valid date range."
           begin: "Publication Year: Please enter a start date."

--- a/blacklight-cornell/lib/blacklight_cornell/cornell_catalog.rb
+++ b/blacklight-cornell/lib/blacklight_cornell/cornell_catalog.rb
@@ -116,16 +116,12 @@ module BlacklightCornell::CornellCatalog extend Blacklight::Catalog
       end
     end
 
-    # Sanitize query for constraints display
-    if  !params[:q].blank? && !params[:search_field].blank?
-      if params[:q].include?('%2520')
-        params[:q].gsub!('%2520',' ')
-      end
-      if params[:q].include?('%2F') or params[:q].include?('/')
-        params[:q].gsub!('%2F','')
-        params[:q].gsub!('/','')
-      end
-      params[:q] = sanitize(params)
+    # Check for img html value and return to root with flash message
+    if params[:q].present? && params[:q].include?('<img')
+      # :nocov:
+        Rails.logger.error("Search error:  #{__FILE__}:#{__LINE__}  q = #{params[:q].inspect}")
+      # :nocov:
+      redirect_to root_path, flash: { notice: I18n.t('blacklight.search.errors.invalid_query') }
     end
 
     # Query solr for document list
@@ -443,25 +439,5 @@ private
       alert = 'order'
     end
     return alert
-  end
-
-  def sanitize(q)
-    if q[:q].include?('<img')
-
-      # :nocov:
-        Rails.logger.error("Sanitize error:  #{__FILE__}:#{__LINE__}  q = #{q[:q].inspect}")
-      # :nocov:
-
-      redirect_to root_path
-    else
-      q = params[:q].rstrip
-      while (q[-1] == "/" or q[-1] == "\\") do
-        if q[-1] == "/" or q[-1] == "\\"
-          q[-1] = ""
-          q = q.rstrip
-        end
-      end
-      return q
-    end
   end
 end

--- a/blacklight-cornell/lib/blacklight_cornell/cornell_catalog.rb
+++ b/blacklight-cornell/lib/blacklight_cornell/cornell_catalog.rb
@@ -116,14 +116,6 @@ module BlacklightCornell::CornellCatalog extend Blacklight::Catalog
       end
     end
 
-    # Check for img html value and return to root with flash message
-    if params[:q].present? && params[:q].include?('<img')
-      # :nocov:
-        Rails.logger.error("Search error:  #{__FILE__}:#{__LINE__}  q = #{params[:q].inspect}")
-      # :nocov:
-      redirect_to root_path, flash: { notice: I18n.t('blacklight.search.errors.invalid_query') }
-    end
-
     # Query solr for document list
     (@response, deprecated_document_list) = search_service.search_results(session['search_limit_exceeded'])
 

--- a/blacklight-cornell/spec/models/search_builder_spec.rb
+++ b/blacklight-cornell/spec/models/search_builder_spec.rb
@@ -198,6 +198,37 @@ RSpec.describe SearchBuilder, type: :model do
       end
     end
 
+    context 'query with double-encoded spaces (%2520)' do
+      it 'replaces %2520 with a space' do
+        query = 'test%2520query'
+        expect(search_builder.clean_q(query)).to eq('test query')
+      end
+    end
+
+    context 'query with encoded forward slashes (%2F) or forward slashes (/)' do
+      it 'removes %2F from the query' do
+        query = 'test %2F query'
+        expect(search_builder.clean_q(query)).to eq('test query')
+      end
+
+      it 'removes / from the query' do
+        query = 'test / query'
+        expect(search_builder.clean_q(query)).to eq('test query')
+      end
+    end
+
+    context 'query with trailing backslashes' do
+      it 'removes trailing backslashes' do
+        query = 'test query\\'
+        expect(search_builder.clean_q(query)).to eq('test query')
+      end
+
+      it 'removes multiple trailing backslashes' do
+        query = 'test query\\\\\\'
+        expect(search_builder.clean_q(query)).to eq('test query')
+      end
+    end
+
     context 'query with escapable special characters' do
       it 'escapes all special characters' do
         colon_query = 'oh: hi'

--- a/blacklight-cornell/spec/models/search_builder_spec.rb
+++ b/blacklight-cornell/spec/models/search_builder_spec.rb
@@ -207,13 +207,13 @@ RSpec.describe SearchBuilder, type: :model do
 
     context 'query with encoded forward slashes (%2F) or forward slashes (/)' do
       it 'removes %2F from the query' do
-        query = 'test %2F query'
-        expect(search_builder.clean_q(query)).to eq('test query')
+        query = 'test%2Fquery'
+        expect(search_builder.clean_q(query)).to eq('testquery')
       end
 
       it 'removes / from the query' do
         query = 'test / query'
-        expect(search_builder.clean_q(query)).to eq('test query')
+        expect(search_builder.clean_q(query)).to eq('test  query')
       end
     end
 


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description

This fixes issues with the asynchronous loading of call number facets when forward slashes are present. This JS code relies to pulling the search parameters directly from the URL: https://github.com/cul-it/blacklight-cornell/blob/c05e1472d039ed0ffaf12443a0b27a16cc4d0db4/blacklight-cornell/app/assets/javascripts/facets.js#L34

However, the sanitization of the forward slashes was not in the SearchBuilder model. This moves the related code from the BlacklightCornell::CornellCatalog module to the SearchBuilder mode, along with other similar query sanitization for backslashes and double-encoded spaces.

I also did some general clean up of the code and added some tests to the existing SearchBuilder spec.

<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-882](<https://culibrary.atlassian.net/browse/DACCESS-882>) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [ ] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes

<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
See test URLs in the Jira ticket. You can also try out different combinations of special characters across basic and advanced search types.

<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-882]: https://culibrary.atlassian.net/browse/DACCESS-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ