### PR TITLE
DACCESS-916 Update View all catalog result link and refactor bento_all_results_links

### DIFF
--- a/blacklight-cornell/app/controllers/search_controller.rb
+++ b/blacklight-cornell/app/controllers/search_controller.rb
@@ -110,33 +110,6 @@ class SearchController < ApplicationController
     sort_panes @results, display_type
   end
 
-  # Return a URL for the 'view all' links. format only matters for Blacklight format facets
-  def all_items_url(engine_id, query, format)
-    if engine_id == "digitalCollections"
-      query = query.gsub("&", "%26")
-      "https://digital.library.cornell.edu/catalog?utf8=%E2%9C%93&q=#{query}&search_field=all_fields"
-    elsif engine_id == "institutionalRepositories"
-      query = query.gsub("&", "%26")
-      "institutional_repositories/index?q=#{query}"
-    elsif engine_id == "libguides"
-      query = query.gsub("&", "%26")
-      "http://guides.library.cornell.edu/srch.php?q=#{query}"
-    elsif engine_id == "ebsco_eds"
-      query = query.gsub("&", "%26")
-      query = "https://discovery.ebsco.com/c/u2yil2/results?q=#{query}"
-    else
-      # Need to pass pluses through as urlencoded characters in order to preserve
-      # the Solr query format.
-      path = "/"
-      if format == "all"
-        escaped = { q: query }.to_param
-      else
-        escaped = { "f[format][]" => format, q: query, search_field: "all_fields" }.to_param
-      end
-      escaped_search_url = path + "?" + escaped
-    end
-  end
-
   # In order to trick bento_search into thinking that our results from our single Solr query are
   # a group of results for different item formats, we have to take an extra step here to parse out
   # the one result from the Solr query into the different formats and create a BentoSearch:: Results

--- a/blacklight-cornell/app/helpers/single_search_helper.rb
+++ b/blacklight-cornell/app/helpers/single_search_helper.rb
@@ -33,7 +33,7 @@ module SingleSearchHelper
       if query.present?
         "https://discovery.ebsco.com/c/u2yil2/results?#{URI.encode_www_form(q: query)}"
       else
-        "https://discovery.ebsco.com/c/u2yil2/results"
+        "https://discovery.ebsco.com/c/u2yil2"
       end
     when "digitalCollections"
       "https://digital.library.cornell.edu/catalog?utf8=%E2%9C%93&#{URI.encode_www_form(q: query)}&search_field=all_fields"

--- a/blacklight-cornell/app/helpers/single_search_helper.rb
+++ b/blacklight-cornell/app/helpers/single_search_helper.rb
@@ -15,47 +15,36 @@ module SingleSearchHelper
     tr(" -", "_").
     downcase
   end
-  
-  def ss_uri_encode (link_url)
-    link_url = link_url.gsub('% ','%25%20') unless link_url.match('%25')
-    link_url = link_url.gsub('$','%24')
-    link_url = link_url.gsub(';','%3B')
-    link_url = link_url.gsub(' ','%20')
-    link_url = link_url.gsub('[','%5B')
-    link_url = link_url.gsub(']','%5D')
-    #  -# link_url = link_url.gsub('=','%3D')
-    #  -# link_url = link_url.gsub('&','%26')
-    link_url = link_url.gsub('"','%22')
-    link_url = link_url.gsub('(','%28')
-    link_url = link_url.gsub(')','%29')
-  end
 
   def is_catalog_pane?(key)
     ['ebsco_eds', 'libguides', 'digitalCollections', 'institutionalRepositories'].exclude?(key)
   end
 
   def bento_all_results_link(key)
+    # our app chooses to use 'q' as the query param; the ajax loading controller
+    # uses 'query'.This ordinarily is fine, but since we want this layout to work
+    # for both, we have to look for both, oh well.
+    query = params[:q] || params[:query]
+
     case key
     when "libguides"
-      link = 'http://guides.library.cornell.edu/libguides/home'
+      "https://guides.library.cornell.edu/libguides/home"
     when "ebsco_eds"
-      bq = params[:q] || params[:query]
-      if bq.present?
-        link = "https://discovery.ebsco.com/c/u2yil2/results?q=#{bq}"
+      if query.present?
+        "https://discovery.ebsco.com/c/u2yil2/results?#{URI.encode_www_form(q: query)}"
       else
-        link = "https://discovery.ebsco.com/c/u2yil2"
+        "https://discovery.ebsco.com/c/u2yil2/results"
       end
     when "digitalCollections"
-      link = controller.all_items_url(key, params[:q] || params[:query], bento_blacklight_format(key))
+      "https://digital.library.cornell.edu/catalog?utf8=%E2%9C%93&#{URI.encode_www_form(q: query)}&search_field=all_fields"
+    when "institutionalRepositories"
+      institutional_repositories_index_path(q: query)
+    when "catalog"
+      search_catalog_path(q: query, search_field: "all_fields")
     else
-      # our app chooses to use 'q' as the query param; the ajax loading controller
-      # uses 'query'.This ordinarily is fine, but since we want this layout to work
-      # for both, we have to look for both, oh well.
-      link = controller.all_items_url(key, params[:q] || params[:query], bento_blacklight_format(key))
-      link = request.protocol + request.host_with_port + '/' + link
+      format = bento_blacklight_format(key)
+      search_catalog_path(q: query, search_field: "all_fields", f: {format: [format]})
     end
-
-    link_url = ss_uri_encode(link)
   end
 
   def bento_title(key)

--- a/blacklight-cornell/app/helpers/single_search_helper.rb
+++ b/blacklight-cornell/app/helpers/single_search_helper.rb
@@ -28,22 +28,18 @@ module SingleSearchHelper
 
     case key
     when "libguides"
-      "https://guides.library.cornell.edu/libguides/home"
+      base_url(key)
     when "ebsco_eds"
-      if query.present?
-        "https://discovery.ebsco.com/c/u2yil2/results?#{URI.encode_www_form(q: query)}"
-      else
-        "https://discovery.ebsco.com/c/u2yil2"
-      end
+      query.present? ? "#{base_url(key)}/results?#{{ q: query }.to_query}" : base_url(key)
     when "digitalCollections"
-      "https://digital.library.cornell.edu/catalog?utf8=%E2%9C%93&#{URI.encode_www_form(q: query)}&search_field=all_fields"
+      "#{base_url(key)}/catalog?#{{ q: query, search_field: "all_fields", utf8: "✓" }.to_query}"
     when "institutionalRepositories"
       institutional_repositories_index_path(q: query)
     when "catalog"
       search_catalog_path(q: query, search_field: "all_fields")
     else
       format = bento_blacklight_format(key)
-      search_catalog_path(q: query, search_field: "all_fields", f: {format: [format]})
+      search_catalog_path(q: query, search_field: "all_fields", f: { format: [format] })
     end
   end
 
@@ -59,4 +55,11 @@ module SingleSearchHelper
     key
   end
 
+  private 
+
+  def base_url(key)
+    BentoSearch.get_engine(key).configuration.base_url
+  rescue BentoSearch::NoSuchEngine
+    ""
+  end
 end

--- a/blacklight-cornell/app/views/single_search/_pane_results.html.erb
+++ b/blacklight-cornell/app/views/single_search/_pane_results.html.erb
@@ -34,8 +34,7 @@
       <% end %>
       <% if is_catalog_pane?(key) %>
         <div class="bento_pane_advanced">
-          <% qp2 = "f%5Bformat%5D%5B%5D=#{bento_blacklight_format(key)}&op_row%5B%5D=AND&q_row%5B%5D=#{ss_uri_encode(params[:q]).gsub('&','%26')}&search_field_row%5B%5D=all_fields" %>
-          or use <%= link_to 'advanced search',"edit?#{qp2}", {:onclick => "javascript:_paq.push(['trackEvent', 'advancedLink', '#{bento_blacklight_format(key)}'])"}  %>
+          or use <%= link_to 'advanced search', advanced_search_edit_path(convert_to_advanced_params(q: params[:q], search_field: "all_fields", f: {format: [bento_blacklight_format(key)]})), {:onclick => "javascript:_paq.push(['trackEvent', 'advancedLink', '#{bento_blacklight_format(key)}'])"}  %>
         </div>
       <% end %>
     </div>

--- a/blacklight-cornell/app/views/single_search/_pane_results.html.erb
+++ b/blacklight-cornell/app/views/single_search/_pane_results.html.erb
@@ -34,7 +34,7 @@
       <% end %>
       <% if is_catalog_pane?(key) %>
         <div class="bento_pane_advanced">
-          or use <%= link_to 'advanced search', advanced_search_edit_path(convert_to_advanced_params(q: params[:q], search_field: "all_fields", f: {format: [bento_blacklight_format(key)]})), {:onclick => "javascript:_paq.push(['trackEvent', 'advancedLink', '#{bento_blacklight_format(key)}'])"}  %>
+          or use <%= link_to 'advanced search', advanced_search_edit_path(convert_to_advanced_params(q: params[:q], search_field: "all_fields", f: { format: [bento_blacklight_format(key)] })), {:onclick => "javascript:_paq.push(['trackEvent', 'advancedLink', '#{bento_blacklight_format(key)}'])"}  %>
         </div>
       <% end %>
     </div>

--- a/blacklight-cornell/app/views/single_search/index.html.erb
+++ b/blacklight-cornell/app/views/single_search/index.html.erb
@@ -70,7 +70,7 @@
                     <ul class="fa-ul">
                       <li>
                         <i class="fa fa-arrow-right"></i>
-                        <%= link_to 'View all Catalog results', "/?q=#{query}" %>
+                        <%= link_to 'View all Catalog results', bento_all_results_link("catalog") %>
                       </li>
                       <li>
                         <i class="fa fa-arrow-right"></i>

--- a/blacklight-cornell/config/initializers/bento_search.rb
+++ b/blacklight-cornell/config/initializers/bento_search.rb
@@ -21,6 +21,7 @@ BentoSearch.register_engine('ebsco_eds') do |conf|
 	conf.title = "Articles & Full Text"
 	conf.for_display = {:decorator => "EbscoEdsArticleDecorator"}
 	conf.highlighting = false
+	conf.base_url = "https://discovery.ebsco.com/c/u2yil2"
 end
 
 # TODO: I don't think we use this engine at all - we just use the configuration link in CornellCatalog#index
@@ -43,6 +44,7 @@ BentoSearch.register_engine('digitalCollections') do |conf|
 	conf.engine = 'BentoSearch::DigitalCollectionsEngine'
 	conf.title = 'Digital Collections'
 	conf.for_display = {:decorator => "DigitalCollections"}
+	conf.base_url = "https://digital.library.cornell.edu"
 end
 
 BentoSearch.register_engine('institutionalRepositories') do |conf|
@@ -55,6 +57,7 @@ BentoSearch.register_engine('libguides') do |conf|
 	conf.engine = 'BentoSearch::LibguidesEngine'
 	conf.title = 'Research Guides'
 	conf.for_display = {:decorator => "DigitalCollections"}
+	conf.base_url = "https://guides.library.cornell.edu"
 end
 
 BentoSearch.register_engine('solr') do |conf|

--- a/blacklight-cornell/spec/helpers/single_search_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/single_search_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SingleSearchHelper, type: :helper do
 
       it 'returns the correct URL without query' do
         allow(helper).to receive(:params).and_return({})
-        expect(helper.bento_all_results_link('ebsco_eds')).to eq('https://discovery.ebsco.com/c/u2yil2/results')
+        expect(helper.bento_all_results_link('ebsco_eds')).to eq('https://discovery.ebsco.com/c/u2yil2')
       end
     end
 

--- a/blacklight-cornell/spec/helpers/single_search_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/single_search_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SingleSearchHelper, type: :helper do
 
     context 'when key is libguides' do
       it 'returns the correct URL' do
-        expect(helper.bento_all_results_link('libguides')).to eq('https://guides.library.cornell.edu/libguides/home')
+        expect(helper.bento_all_results_link('libguides')).to eq('https://guides.library.cornell.edu')
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe SingleSearchHelper, type: :helper do
 
     context 'when key is digitalCollections' do
       it 'returns the correct URL' do
-        expect(helper.bento_all_results_link('digitalCollections')).to eq("https://digital.library.cornell.edu/catalog?utf8=%E2%9C%93&q=peanut+butter+%26+jelly&search_field=all_fields")
+        expect(helper.bento_all_results_link('digitalCollections')).to eq("https://digital.library.cornell.edu/catalog?q=peanut+butter+%26+jelly&search_field=all_fields&utf8=%E2%9C%93")
       end
     end
 

--- a/blacklight-cornell/spec/helpers/single_search_helper_spec.rb
+++ b/blacklight-cornell/spec/helpers/single_search_helper_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe SingleSearchHelper, type: :helper do
+  describe '#bento_all_results_link' do
+    let(:query) { 'peanut butter & jelly' }
+
+    before do
+      allow(helper).to receive(:params).and_return({ q: query })
+    end
+
+    context 'when key is libguides' do
+      it 'returns the correct URL' do
+        expect(helper.bento_all_results_link('libguides')).to eq('https://guides.library.cornell.edu/libguides/home')
+      end
+    end
+
+    context 'when key is ebsco_eds' do
+      it 'returns the correct URL with query' do
+        expect(helper.bento_all_results_link('ebsco_eds')).to eq("https://discovery.ebsco.com/c/u2yil2/results?q=peanut+butter+%26+jelly")
+      end
+
+      it 'returns the correct URL without query' do
+        allow(helper).to receive(:params).and_return({})
+        expect(helper.bento_all_results_link('ebsco_eds')).to eq('https://discovery.ebsco.com/c/u2yil2/results')
+      end
+    end
+
+    context 'when key is digitalCollections' do
+      it 'returns the correct URL' do
+        expect(helper.bento_all_results_link('digitalCollections')).to eq("https://digital.library.cornell.edu/catalog?utf8=%E2%9C%93&q=peanut+butter+%26+jelly&search_field=all_fields")
+      end
+    end
+
+    context 'when key is institutionalRepositories' do
+      it 'returns the correct path' do
+        expect(helper.bento_all_results_link('institutionalRepositories')).to eq('/institutional_repositories/index?q=peanut+butter+%26+jelly')
+      end
+    end
+
+    context 'when key is catalog' do
+      it 'returns the correct path' do
+        expect(helper.bento_all_results_link('catalog')).to eq('/catalog?q=peanut+butter+%26+jelly&search_field=all_fields')
+      end
+    end
+
+    context 'when key is a format (ex. Book)' do
+      it 'returns the catalog path with a format facet' do
+        expect(helper.bento_all_results_link('Book')).to eq('/catalog?f%5Bformat%5D%5B%5D=Book&q=peanut+butter+%26+jelly&search_field=all_fields')
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
<!-- Briefly describe what this PR does and why -->
- Updated “View all Catalog results” link in the bento search to include `search_field=all_fields`
- Refactored code related to the bento all results links, removing redundancies and improving how we encode the urls
  - This includes removing `ss_uri_encode`, which was also used for an advanced search link that needed to be updated.
  - Question: Is there a better way to handle the external links? 

<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-916](<https://culibrary.atlassian.net/browse/DACCESS-916>) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [x] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes

<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
<!--
    Instructions so a reviewer can verify this PR locally.
    Include edge cases, test data, URLs, Staging or Integration environments used that may be helpful.
-->
- Execute a bento search and verify that the affected links are working expected, including all "View More" and "advanced search" links
- Try different combinations of special characters in bento search queries to ensure that encoding is working as expected

<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-916]: https://culibrary.atlassian.net/browse/DACCESS-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ