### PR TITLE
DACCESS-910: Chromium version, early test build error detection, and --no-cache fix

### DIFF
--- a/blacklight-cornell/features/browse/browse_search.feature
+++ b/blacklight-cornell/features/browse/browse_search.feature
@@ -50,7 +50,7 @@ Feature: Browse search
   Scenario: Search for author-title combination
     Given I literally go to browse
         And I fill in the authorities search box with 'Beethoven, Ludwig van, 1770-1827 | Fidelio (1805)'
-        And I select 'Author (A-Z) Sorted By Name' from the 'browse_type' drop-down
+        And I select 'Author Browse (A-Z) Sorted By Name' from the 'browse_type' drop-down
         And I press 'search'
     Then I should see the label 'Beethoven, Ludwig van, 1770-1827 | Fidelio (1805)'
     Then click on first link "Beethoven, Ludwig van, 1770-1827"
@@ -63,7 +63,7 @@ Feature: Browse search
   Scenario: Search for author-title combination
     Given I literally go to browse
         And I fill in the authorities search box with 'Martin, Courtney E.'
-        And I select 'Author (A-Z) Sorted By Name' from the 'browse_type' drop-down
+        And I select 'Author Browse (A-Z) Sorted By Name' from the 'browse_type' drop-down
         And I press 'search'
         Then I should see the label 'Martin, Courtney E.'
         Then click on first link "Martin, Courtney E."
@@ -74,7 +74,7 @@ Feature: Browse search
   Scenario: Browse author-title combinations and view heading details
     Given I literally go to browse
       And I fill in the authorities search box with 'McKenna, Maryn'
-      And I select 'Author (A-Z) Sorted By Title' from the 'browse_type' drop-down
+      And I select 'Author Browse (A-Z) Sorted By Title' from the 'browse_type' drop-down
       And I press 'search'
     Then I should see the label 'McKenna, Maryn. | Big chicken'
     Then click on first link "Author-Title info"
@@ -167,6 +167,6 @@ Feature: Browse search
 
   Examples:
       | search | browse | heading | count |
-      | Rowling | Author (A-Z) Sorted By Name | Rowling, J. K. | 8 |
+      | Rowling | Author Browse (A-Z) Sorted By Name | Rowling, J. K. | 8 |
       | China | Subject Browse (A-Z) | China | 4 |
       | Wizards > Juvenile fiction | Subject Browse (A-Z) | Wizards > Juvenile fiction | 7 |

--- a/docker/trixie/Dockerfile
+++ b/docker/trixie/Dockerfile
@@ -90,7 +90,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # How do we pin versions for build-essential & libvips?
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends vim=2:9.1.* \
-    chromium=147.0.* chromium-driver=147.0.* chromium-common=147.0.* \
+    chromium=1* chromium-driver=1* chromium-common=1* \
     libfontconfig1=2.15.0-2.* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/trixie/Dockerfile
+++ b/docker/trixie/Dockerfile
@@ -90,7 +90,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # How do we pin versions for build-essential & libvips?
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends vim=2:9.1.* \
-    chromium=1* chromium-driver=1* chromium-common=1* \
+    chromium chromium-driver chromium-common \
     libfontconfig1=2.15.0-2.* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     parameters {
         string(name: 'NUM_PROCESSES', defaultValue: '2', description: 'Number of processes to use for parallel cucumber tests')
         string(name: 'CUCUMBER_FEATURE_TESTS', defaultValue: '', description: "Leave blank to run all tests.\nTo run a specific suite, add file argument like features/catalog_search/results_list.feature\nTo run a specific test, add line argument like features/catalog_search/results_list.feature:317")
+        booleanParam(name: 'TEST_BUILD_NO_CACHE', defaultValue: false, description: 'Rebuild test image with --no-cache') // --no-cache option that can be manually triggered on builds with Jenkins
     }
     stages {
         // use this version for normal situations
@@ -26,6 +27,7 @@ pipeline {
                             export JENKINS_WORKSPACE=${WORKSPACE}
                             export NUM_PROCESSES=${params.NUM_PROCESSES}
                             export TEST_ID=${env.TEST_ID}
+                            export TEST_BUILD_NO_CACHE=${params.TEST_BUILD_NO_CACHE}
                             ./jenkins/cucumber-features.sh
                         """
                     }

--- a/jenkins/cucumber-features.sh
+++ b/jenkins/cucumber-features.sh
@@ -18,7 +18,14 @@ export DOCKER_GID=$(id -g)
 mkdir -p ${COVERAGE_PATH}
 project_name="container-discovery-test-${TEST_ID}"
 echo "Cucumber tests for ${project_name}"
-docker compose -f docker-compose-test.yaml build
+
+# --no-cache build option with Jenkins
+build_args=""
+if [ "${TEST_BUILD_NO_CACHE:-false}" = "true" ]; then
+  build_args="--no-cache"
+fi
+
+docker compose -f docker-compose-test.yaml build ${build_args}
 docker compose -p $project_name -f docker-compose-test.yaml up --exit-code-from webapp
 EXIT_CODE=$?
 docker compose -p $project_name -f docker-compose-test.yaml down --volumes --remove-orphans

--- a/jenkins/cucumber-features.sh
+++ b/jenkins/cucumber-features.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 echo ""
 echo "*********************************************************************************"
 echo "Running cucumber tests in container"


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
<!-- Briefly describe what this PR does and why -->

* UpdatedChromium version to resolve missing Chromium dependency errors (again).
* Unpinned Chromium dependencies to prevent frequent test build breaks
* Set up test to use `set -e` to trigger errors when test builds break.
* Tests can now be manually built with `--no-cache` flag triggered in Jenkins

Resolves error:
```
#7 5.852 Package chromium is not available, but is referred to by another package.
#7 5.852 This may mean that the package is missing, has been obsoleted, or
#7 5.852 is only available from another source
#7 5.852 However the following packages replace it:
#7 5.852   chromium-shell chromium-sandbox chromium-common chromium-bsu
#7 5.852 
#7 5.852 Package chromium-common is not available, but is referred to by another package.
#7 5.852 This may mean that the package is missing, has been obsoleted, or
#7 5.852 is only available from another source
#7 5.852 
#7 5.852 Package chromium-driver is not available, but is referred to by another package.
#7 5.852 This may mean that the package is missing, has been obsoleted, or
#7 5.852 is only available from another source
#7 5.852 
#7 5.860 E: Version '147.0.*' for 'chromium' was not found
#7 5.860 E: Version '147.0.*' for 'chromium-driver' was not found
#7 5.860 E: Version '147.0.*' for 'chromium-common' was not found
#7 ERROR: process "/bin/sh -c apt-get update -qq &&     apt-get install -y --no-install-recommends vim=2:9.1.*     chromium=147.0.* chromium-driver=147.0.* chromium-common=147.0.*     libfontconfig1=2.15.0-2.* &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     rm -rf /src/*.deb &&     mkdir -p /root/.aws /root/user-data-0 /root/user-data-1 /root/user-data-2 /root/user-data-3 /root/user-data-4 &&     chmod -R a+rwX /root # Let the Jenkins user (DOCKER_UID) write here when tests run" did not complete successfully: exit code: 100
```

After fixing Chromium dependency errors and test built successfully, I discovered the Browse tests were failing after my prior fix. Tests passed on the prior PR due to tests not building from new code (thanks chromium) and using older cached code

Fixes:
```
Failing Scenarios:
cucumber -p jenkins_lax features/browse/browse_search.feature:50 # Scenario: Search for author-title combination
cucumber -p jenkins_lax features/browse/browse_search.feature:63 # Scenario: Search for author-title combination
cucumber -p jenkins_lax features/browse/browse_search.feature:74 # Scenario: Browse author-title combinations and view heading details
cucumber -p jenkins_lax features/browse/browse_search.feature:170 # Scenario Outline: Browse result counts should match catalog counts

```


<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- Continuance of: [DACCESS-910](https://culibrary.atlassian.net/browse/DACCESS-910) 
- [DACCESS-921](https://culibrary.atlassian.net/browse/DACCESS-921) 
- [DACCESS-922](https://culibrary.atlassian.net/browse/DACCESS-922) 

<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [x] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes


<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 📸 Screenshots
Testing will now produce an error at the beginning stages if there is build error from old/missing dependencies.
This allows developers to be alerted of these issues to help facilitate speedier fixes in the future. 

Example Result with similar breaking dependence issue (introduced for testing purposes)
<img width="803" height="226" alt="image" src="https://github.com/user-attachments/assets/93293061-7072-4635-87d8-b0e4aaced3be" />

New `--no-cache` flag can now be manually triggered with builds if we suspect there are test caching problems
<img width="611" height="523" alt="image" src="https://github.com/user-attachments/assets/1dcc8768-c493-4e2d-9555-3e996ec65779" />


<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-910]: https://culibrary.atlassian.net/browse/DACCESS-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ