### PR TITLE
DACCESS-933: update link to E-Journal Titles

### DIFF
--- a/blacklight-cornell/app/views/catalog/_home_text.html.erb
+++ b/blacklight-cornell/app/views/catalog/_home_text.html.erb
@@ -23,7 +23,7 @@
     		<ul>
 			  <li><%= render :partial => 'shared/link_articles_fulltext' %></li>
 			  <li><a href="/databases">Databases</a></li>
-			  <li><a href="http://erms.library.cornell.edu/">E-journal Titles</a></li>
+			  <li><a href="https://publications.ebsco.com/?profileid=pfui&groupid=main&custid=s9001366">E-journal Titles</a></li>
               <li><a href="/digitalcollections">Digital Collections</a></li>
 			</ul>
     	</div>

--- a/blacklight-cornell/app/views/shared/_footer.html.erb
+++ b/blacklight-cornell/app/views/shared/_footer.html.erb
@@ -14,7 +14,7 @@
             <li><a href="http://catalog.library.cornell.edu">Catalog</a></li>
             <li><%= render :partial => 'shared/link_articles_fulltext' %></li>
             <li><a href="/databases">Databases</a></li>
-            <li><a href="http://erms.library.cornell.edu/">E-journal Titles</a></li>
+            <li><a href="https://publications.ebsco.com/?profileid=pfui&groupid=main&custid=s9001366">E-journal Titles</a></li>
             <li><a href="https://www.library.cornell.edu/collections/visual-resources/">Images</a></li>
             <li class="d-block d-sm-none"><a href="/myaccount/login">My Account</a></li>
           </ul>

--- a/blacklight-cornell/app/views/single_search/_search_options.html.erb
+++ b/blacklight-cornell/app/views/single_search/_search_options.html.erb
@@ -13,7 +13,7 @@
       <%= link_to 'Databases', '/databases' %>
     </li>
     <li>
-      <%= link_to 'E-journal Titles', "http://erms.library.cornell.edu/" %>
+      <%= link_to 'E-journal Titles', "https://publications.ebsco.com/?profileid=pfui&groupid=main&custid=s9001366" %>
     </li>
     <li>
       <%= link_to 'Images', "https://www.library.cornell.edu/collections/visual-resources/" %>


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description

We have several links to E-Journal Titles that point to erms.library.cornell.edu. There were multiple reports that this link was not working. The problem was with the redirector service. Peter McCracken said it was OK to link directly to EBSCO rather than the erms URL.

Note that erms.library.cornell.edu used to be a locally-hosted e-journals interface, so this was a legacy domain that we likely kept up and redirected to avoid broken links, etc.

We updated the link at www.library.cornell.edu at the time of the problem and planned to update the catalog during the next sprint.

<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
- [DACCESS-933](<https://culibrary.atlassian.net/browse/DACCESS-933>) 

<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] `feature` — New feature or enhancement
- [ ] `bug` — Bug fix
- [X] `maintenance` — Maintenance
- [ ] `accessibility` — Accessibility updates
- [ ] `documentation` — Documentation changes

<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
<!--
    Instructions so a reviewer can verify this PR locally.
    Include edge cases, test data, URLs, Staging or Integration environments used that may be helpful.
-->

The E-Journal Titles link appears in the following places:

- site-wide footer
- catalog home page
- bento search home page (/search)

<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [ ] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [ ] No secrets, API keys, or credentials committed

[DACCESS-933]: https://culibrary.atlassian.net/browse/DACCESS-933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ