### PR TITLE
DACCESS-917 Update search builder to process query with no search_field

### DIFF
--- a/blacklight-cornell/app/models/search_builder.rb
+++ b/blacklight-cornell/app/models/search_builder.rb
@@ -78,7 +78,7 @@ class SearchBuilder < Blacklight::SearchBuilder
       solr_parameters[:search_field] = 'advanced'
 
       solr_parameters[:q] = build_advanced_search_query(blacklight_params)
-    elsif blacklight_params[:search_field].present?
+    else
       # Remove any unexpected advanced search params
       if blacklight_params[:advanced_query].present?
         blacklight_params.delete(:advanced_query)

--- a/blacklight-cornell/app/models/search_builder.rb
+++ b/blacklight-cornell/app/models/search_builder.rb
@@ -78,7 +78,7 @@ class SearchBuilder < Blacklight::SearchBuilder
       solr_parameters[:search_field] = 'advanced'
 
       solr_parameters[:q] = build_advanced_search_query(blacklight_params)
-    else
+    elsif blacklight_params[:q].present? || blacklight_params[:search_field].present?
       # Remove any unexpected advanced search params
       if blacklight_params[:advanced_query].present?
         blacklight_params.delete(:advanced_query)

--- a/blacklight-cornell/features/catalog_search/results_list.feature
+++ b/blacklight-cornell/features/catalog_search/results_list.feature
@@ -159,13 +159,13 @@ Feature: Results list
   @next_facet
   @javascript
   Scenario: Search with results,
-    Given I view the search results list for 'title'='cornell history'
+    Given I view the search results list for 'title'='ocean'
     Then I should get results
-    Then I should see the text 'Cornell history journal'
-    Then click on first link "Cornell history journal"
+    Then I should see the text 'Ocean thermal energy conversion'
+    Then click on first link "Ocean thermal energy conversion"
     Then click on first link "Next »"
     Then click on first link "Previous"
-    Then I should see the text 'Cornell history journal'
+    Then I should see the text 'Ocean thermal energy conversion'
 
   # Combinatorial Algorithms, Algorithmic Press
   # # the selected sort field is visible, the unselected is not visible,though present in the html.

--- a/blacklight-cornell/features/catalog_search/results_list.feature
+++ b/blacklight-cornell/features/catalog_search/results_list.feature
@@ -159,13 +159,13 @@ Feature: Results list
   @next_facet
   @javascript
   Scenario: Search with results,
-    Given I view the search results list for 'title'='ocean'
+    Given I view the search results list for 'title'='cornell history'
     Then I should get results
-    Then I should see the text 'Ocean thermal energy conversion'
-    Then click on first link "Ocean thermal energy conversion"
+    Then I should see the text 'Cornell history journal'
+    Then click on first link "Cornell history journal"
     Then click on first link "Next »"
     Then click on first link "Previous"
-    Then I should see the text 'Ocean thermal energy conversion'
+    Then I should see the text 'Cornell history journal'
 
   # Combinatorial Algorithms, Algorithmic Press
   # # the selected sort field is visible, the unselected is not visible,though present in the html.

--- a/blacklight-cornell/spec/models/search_builder_spec.rb
+++ b/blacklight-cornell/spec/models/search_builder_spec.rb
@@ -1195,7 +1195,30 @@ RSpec.describe SearchBuilder, type: :model do
       allow(search_builder).to receive(:blacklight_params) { blacklight_params }
     end
 
-    context 'simple catalog search' do
+    context 'simple catalog search with no search_field param' do
+      let(:blacklight_params) { { q: q } }
+      let(:solr_params) { { q: q, sort: 'score desc, pub_date_sort desc, title_sort asc' } }
+
+      context '1 search term' do
+        let(:q) { 'test'}
+
+        it 'transforms expected solr params' do
+          search_builder.set_query(solr_params)
+          expect(solr_params[:q]).to eq('("test") OR phrase:"test"')
+          end
+        end
+
+      context 'multiple search terms' do
+        let(:q) { 'test1 test2 test3'}
+
+        it 'transforms expected solr params' do
+          search_builder.set_query(solr_params)
+          expect(solr_params[:q]).to eq('("test1" AND "test2" AND "test3") OR phrase:"test1 test2 test3"')
+        end
+      end
+    end
+
+    context 'simple catalog search with search_field param' do
       let(:q) { 'test1 test2 test3'}
       let(:blacklight_params) { { q: q, search_field: search_field } }
       let(:solr_params) { { q: q, sort: 'score desc, pub_date_sort desc, title_sort asc' } }


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
<!-- Briefly describe what this PR does and why -->
Currently there are different results depending on whether or not `search_field=all_fields` is included in a basic search query url. The goal here is to have consistent results by defaulting to `all_fields` when no `search_field` parameter is present.

The reason for the discrepancy is that queries without a `search_field` parameter were not being processed the same way in our search builder. The method `build_simple_search_query` is already capable of handling the absence of a `search_field` parameter by defaulting to `all_fields`, but the method `set_query` was unnecessarily requiring the presence of that parameter before `build_simple_search_query` is called. This changes that conditional. 

<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-917](<https://culibrary.atlassian.net/browse/DACCESS-917>) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [ ] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
<!--
    Instructions so a reviewer can verify this PR locally.
    Include edge cases, test data, URLs, Staging or Integration environments used that may be helpful.
-->

Compare /catalog?q=art%20history with /catalog?q=art+history&search_field=all_fields

<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ