### PR TITLE
DACCESS-940 Update LibGuides API to v1.2, with token caching

### DIFF
--- a/blacklight-cornell/app/search_engines/bento_search/libguides_engine.rb
+++ b/blacklight-cornell/app/search_engines/bento_search/libguides_engine.rb
@@ -72,7 +72,7 @@ class BentoSearch::LibguidesEngine
     end
 
     rescue StandardError => e
-      Rails.logger.error("Failed to retrieve LibGuides auth token. Error: #{e.message}")
+      Rails.logger.error "Failed to retrieve LibGuides auth token. Error: #{e.message}" 
       nil
   end
 

--- a/blacklight-cornell/app/search_engines/bento_search/libguides_engine.rb
+++ b/blacklight-cornell/app/search_engines/bento_search/libguides_engine.rb
@@ -13,19 +13,8 @@ class BentoSearch::LibguidesEngine
       # 'args' should be a normalized search arguments hash including the following elements:
       # :query, :per_page, :start, :page, :search_field, :sort
       bento_results = BentoSearch::Results.new
-
-      guides_response = []
-      path = "http://lgapi-us.libapps.com/1.1/guides/"
-      st = args[:query].gsub(/["”“]/, '')
-      escaped = { site_id: 45, search_terms: st, status: 1, key: ENV["LIBGUIDES_API_KEY"] }.to_param
-      guides_url = path + "?" + escaped
-      guides_response = JSON.load(URI.open(guides_url))
-    rescue Exception => e
-      guides_response = []
-      # :nocov:
-        Rails.logger.error "Runtime Error: #{__FILE__} #{__LINE__} Error:: #{e.inspect}"
-        Rails.logger.error "Guides URL: " + guides_url
-      # :nocov:
+      token = get_auth_token
+      guides_response = get_guides_response(args[:query], token)
     end
 
     results = guides_response[0, 3]
@@ -33,14 +22,66 @@ class BentoSearch::LibguidesEngine
     results.each do |i|
       item = BentoSearch::ResultItem.new
       item.title = i["name"].to_s
-      if i["description"].present?
-        item.abstract = i["description"].to_s
-      end
+      item.abstract = i["description"].to_s if i["description"].present?
       item.link = i["friendly_url"]
       bento_results << item
     end
+    
     bento_results.total_items = 0
-
     return bento_results
   end
+
+  def get_guides_response(search_terms, token)
+    uri = URI("#{ENV["LIBGUIDES_API_URL"]}/guides")
+    uri.query = URI.encode_www_form({ search_terms: search_terms, sort_by: "relevance", status: 1 })
+    response = Net::HTTP.get_response(uri, { "Authorization" => "Bearer #{token}" })
+
+    if response.is_a? Net::HTTPSuccess
+      JSON.parse(response.body)
+    else
+      Rails.logger.error "Net::HTTP Error for #{uri}. HTTP response: #{response.inspect}"
+      []
+    end
+  end
+
+  def get_auth_token
+    cached = Rails.cache.read(cache_key)
+    if cached.present? && cached[:expires_at] > Time.current.to_i + 60
+      cached[:access_token].to_s
+    else
+      client_id = ENV["LIBGUIDES_CLIENT_ID"]
+      client_secret = ENV["LIBGUIDES_CLIENT_SECRET"]
+
+      uri = URI("#{ENV["LIBGUIDES_API_URL"]}/oauth/token")
+      client_data = { client_id: client_id, client_secret: client_secret, grant_type: "client_credentials" }
+      response = Net::HTTP.post_form(uri, client_data)
+
+      if response.is_a? Net::HTTPSuccess
+        token_data = JSON.parse(response.body)
+        access_token = token_data["access_token"].to_s
+        expires_in = token_data["expires_in"].to_i
+        expires_at = (Time.current + (expires_in.present? ? expires_in : 3600).seconds).to_i
+
+        Rails.logger.info "Caching new LibGuides auth token"
+        write_cached_token(access_token, expires_in, expires_at)
+        access_token
+      else
+        Rails.logger.error "Net::HTTP Error for #{uri}. HTTP response: #{response.inspect}"
+        nil
+      end
+    end
+
+    rescue StandardError => e
+      nil
+  end
+
+  private
+    def cache_key
+      "libguides_auth_token"
+    end
+
+    def write_cached_token(access_token, expires_in, expires_at)
+      payload = { access_token: access_token, expires_at: expires_at }
+      Rails.cache.write(cache_key, payload, expires_in: expires_in)
+    end
 end

--- a/blacklight-cornell/app/search_engines/bento_search/libguides_engine.rb
+++ b/blacklight-cornell/app/search_engines/bento_search/libguides_engine.rb
@@ -59,8 +59,8 @@ class BentoSearch::LibguidesEngine
       if response.is_a? Net::HTTPSuccess
         token_data = JSON.parse(response.body)
         access_token = token_data["access_token"].to_s
-        expires_in = token_data["expires_in"].to_i
-        expires_at = (Time.current + (expires_in.present? ? expires_in : 3600).seconds).to_i
+        expires_in = token_data["expires_in"].present? ? token_data["expires_in"].to_i : 3600
+        expires_at = (Time.current + expires_in.seconds).to_i
 
         Rails.logger.info "Caching new LibGuides auth token"
         write_cached_token(access_token, expires_in, expires_at)
@@ -72,6 +72,7 @@ class BentoSearch::LibguidesEngine
     end
 
     rescue StandardError => e
+      Rails.logger.error("Failed to retrieve LibGuides auth token. Error: #{e.message}")
       nil
   end
 

--- a/blacklight-cornell/spec/search_engines/bento_search/libguides_engine_spec.rb
+++ b/blacklight-cornell/spec/search_engines/bento_search/libguides_engine_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+describe BentoSearch::LibguidesEngine do
+  subject(:libguides_engine) { described_class.new }
+
+  before do
+    stub_request(:post, /oauth\/token/)
+      .to_return(body: JSON.dump(access_token: "test-token", expires_in: 3600),
+                status: 200,
+                headers: { "Content-Type" => "application/json" })
+
+    stub_request(:get, /guides/)
+      .to_return(body: JSON.dump([{ "name" => "guide title", "description" => "guide description", "friendly_url" => "https://example.org/guides/123" }]),
+                status: 200,
+                headers: { "Content-Type" => "application/json" })
+
+  end
+
+  describe '#search' do
+    context 'when the LibGuides API returns results' do
+      it 'returns a BentoSearch::Results object with the expected attributes' do
+        results = libguides_engine.search('test')
+        expect(results).to be_a(BentoSearch::Results)
+        expect(results.count).to eq(1)
+        expect(results.first.title).to eq('guide title')
+        expect(results.first.abstract).to eq('guide description')
+        expect(results.first.link).to eq('https://example.org/guides/123')
+        expect(results.total_items).to eq(0)
+      end
+    end
+  end
+
+  describe '#get_guides_response' do
+    context 'when the API returns a successful response' do
+      it 'returns parsed guides array' do
+        arr = libguides_engine.get_guides_response('test', 'test-token')
+        expect(arr).to be_an(Array)
+        expect(arr.first['name']).to eq('guide title')
+      end
+    end
+
+    context 'when the API returns HTTP error' do
+      before do
+        stub_request(:get, /guides/).to_return(status: 500)
+      end
+      
+      it 'returns empty' do
+        arr = libguides_engine.get_guides_response('test', 'test-token')
+        expect(arr).to eq([])
+      end
+    end
+  end
+
+  describe '#get_auth_token' do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+    end
+
+    context 'when a valid token exists' do
+      it 'returns access token string and caches it' do
+        token = libguides_engine.get_auth_token
+        expect(token).to eq('test-token')
+
+        cached = Rails.cache.read("libguides_auth_token")
+        expect(cached).to be_present
+        expect(cached[:access_token]).to eq('test-token')
+      end
+    end
+
+    context 'when the API returns HTTP error' do
+      before do
+        Rails.cache.delete("libguides_auth_token")
+        stub_request(:post, /oauth\/token/).to_return(status: 500)
+      end
+
+      it 'returns nil' do
+        token = libguides_engine.get_auth_token
+        expect(token).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
<!-- Briefly describe what this PR does and why -->

This updates the LibGuides API to v1.2, as v1.1 is now deprecated. The main change is the method of authentication. The new version uses OAuth tokens rather than an API key, so this introduces token caching using the Rails cache. 

I also did some general cleanup to this code. This includes adding "relevance" to the API search query, which enables full-text searching for improved results, and moving the api base url to the env file along with the new client secrets. 

<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-940](<https://culibrary.atlassian.net/browse/DACCESS-940>) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [ ] 🐛 `bug` — Bug fix
- [x] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
<!--
    Instructions so a reviewer can verify this PR locally.
    Include edge cases, test data, URLs, Staging or Integration environments used that may be helpful.
-->

Execute any query in the bento search that would return results for research guides (ex. "art history"). Note that the results will come back differently with this update due to the change in the query parameters. 

<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 📸 Screenshots
<!-- For UI changes, include before/after screenshots. -->



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🚀 Deployment Notes
<!-- Anything special about deploying this? (New env vars required?, etc) -->

3 new environment variables will need to be added: LIBGUIDES_API_URL, LIBGUIDES_CLIENT_ID, LIBGUIDES_CLIENT_SECRET. 


<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-940]: https://culibrary.atlassian.net/browse/DACCESS-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ