### PR TITLE
DACCESS-959: remove bento survey button

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/print.scss
+++ b/blacklight-cornell/app/assets/stylesheets/print.scss
@@ -42,8 +42,7 @@
 	.digitalcollections-search .card,
 	.toplink,
 	.facet-pagination,
-	.navbar-toggler,
-	.survey-button {
+	.navbar-toggler {
 		display: none;
 	}
 

--- a/blacklight-cornell/app/assets/stylesheets/singlesearch.scss
+++ b/blacklight-cornell/app/assets/stylesheets/singlesearch.scss
@@ -359,47 +359,9 @@ div.view-all {
   margin-bottom: 0;
 }
 
-.survey-button {
-  .lwz-btn {
-    font-size: 1.1rem;
-    color: #ffffff;
-    z-index: 999998;
-    padding: .5rem 1rem;
-    width: auto;
-    position: fixed;
-    background-color: $cornell-highlight-red;
-    border: 1px solid $cornell-highlight-red;
-    bottom: -2px;
-    left: calc(90% - 125px);
-    text-decoration: none;
-    border-radius: 0.25rem 0.25rem 0 0;
-  }
-  i {
-    margin-left: 0.5rem;
-    font-size: 90%;
-  }
-}
-
 
 // MEDIA QUERIES
 // -------------------------
-
-// Small devices (landscape phones, 576px and down,)
-@include media-breakpoint-down(sm) {
-  // LibWizard form - Help us redesign! button is static
-  .survey-button {
-    .lwz-btn {
-      position: static;
-      transform: none;
-      width: 200px;
-      margin: 1em auto;
-      display: block;
-      border-radius: 6px;
-      top: auto;
-      right: auto;
-    }
-  }
-}
 
 
 // Small devices (landscape phones, 576px and up)

--- a/blacklight-cornell/app/views/single_search/index.html.erb
+++ b/blacklight-cornell/app/views/single_search/index.html.erb
@@ -301,8 +301,4 @@
   <% end %>
 <% end %>
 
-<div class="survey-button">
-  <a href="https://cornell.libwizard.com/f/single-search" target="_blank" rel="noopener" class="lwz-btn">Help us redesign!<i class="fa fa-external-link" aria-hidden="true"></i><span class="sr-only"> opens a new window</span></a>
-</div>
-
 <%= javascript_include_tag 'search_form', 'data-turbo-track': 'reload' %>


### PR DESCRIPTION
## 📝 Description

Remove the survey button from the bento pages.

## 🔗 Related Issues

- [DACCESS-959](<https://culibrary.atlassian.net/browse/DACCESS-959>) 

## 🔖 Type of Change

- [ ] `feature` — New feature or enhancement
- [ ] `bug` — Bug fix
- [X] `maintenance` — Maintenance
- [ ] `accessibility` — Accessibility updates
- [ ] `documentation` — Documentation changes

## 🧑‍💻 How Reviewers Can Test This

Check that the survey button is no longer on the bento pages:

- bento home page (/search)
- bento results
- bento repository results

## ✅ Checklist
- [ ] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [ ] No secrets, API keys, or credentials committed

[DACCESS-959]: https://culibrary.atlassian.net/browse/DACCESS-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ