### PR TITLE
DACCESS-969 Add fallback fields for abstract and link in guides bento results

### DIFF
--- a/blacklight-cornell/app/search_engines/bento_search/libguides_engine.rb
+++ b/blacklight-cornell/app/search_engines/bento_search/libguides_engine.rb
@@ -22,8 +22,8 @@ class BentoSearch::LibguidesEngine
     results.each do |i|
       item = BentoSearch::ResultItem.new
       item.title = i["name"].to_s
-      item.abstract = i["description"].to_s if i["description"].present?
-      item.link = i["friendly_url"]
+      item.abstract = i["description"].present? ? i["description"].to_s : i["type_label"].to_s
+      item.link = i["friendly_url"].present? ? i["friendly_url"].to_s : i["url"].to_s
       bento_results << item
     end
     

--- a/blacklight-cornell/spec/search_engines/bento_search/libguides_engine_spec.rb
+++ b/blacklight-cornell/spec/search_engines/bento_search/libguides_engine_spec.rb
@@ -10,7 +10,7 @@ describe BentoSearch::LibguidesEngine do
                 headers: { "Content-Type" => "application/json" })
 
     stub_request(:get, /guides/)
-      .to_return(body: JSON.dump([{ "name" => "guide title", "description" => "guide description", "friendly_url" => "https://example.org/guides/123" }]),
+      .to_return(body: JSON.dump([{ "name" => "guide title", "description" => "guide description", "friendly_url" => "https://example.org/123" }]),
                 status: 200,
                 headers: { "Content-Type" => "application/json" })
 
@@ -24,8 +24,27 @@ describe BentoSearch::LibguidesEngine do
         expect(results.count).to eq(1)
         expect(results.first.title).to eq('guide title')
         expect(results.first.abstract).to eq('guide description')
-        expect(results.first.link).to eq('https://example.org/guides/123')
+        expect(results.first.link).to eq('https://example.org/123')
         expect(results.total_items).to eq(0)
+      end
+    end
+
+    context 'when the LibGuides API returns no friendly url or description' do
+      before do
+        stub_request(:get, /guides/)
+          .to_return(body: JSON.dump([{ "name" => "guide title", "type_label" => "guide type", "url" => "https://example.org/456" }]),
+                     status: 200,
+                     headers: { "Content-Type" => "application/json" })
+      end
+
+      it 'uses the type label as the abstract' do
+        results = libguides_engine.search('test')
+        expect(results.first.abstract).to eq('guide type')
+      end
+
+      it 'uses the url as the link' do
+        results = libguides_engine.search('test')
+        expect(results.first.link).to eq('https://example.org/456')
       end
     end
   end


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
<!-- Briefly describe what this PR does and why -->

Some guide results are returning without a link to the guide. We have been using the guide's "friendly url," which is not always present. This change uses the guide's main "url" as a fallback. 

While working on this, I also noticed that we could use a fallback for guide result's abstract as well. When a guide description is not present, it will now add the guide type (ex. "Course Guide," "Subject Guide," etc.), which provides a bit more context.

<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-969](<https://culibrary.atlassian.net/browse/DACCESS-969>) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [x] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [ ] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
<!--
    Instructions so a reviewer can verify this PR locally.
    Include edge cases, test data, URLs, Staging or Integration environments used that may be helpful.
-->

Search "anthropology" in bento search and view 2nd/3rd results under "Research Guides." 

<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 📸 Screenshots
<!-- For UI changes, include before/after screenshots. -->

**_Before_**
<img width="443" height="346" alt="Screenshot 2026-08-21 at 11 15 41 AM" src="https://github.com/user-attachments/assets/a67e0e63-45c9-4cec-88ad-b4659212af8f" />

**_After_**
<img width="445" height="404" alt="Screenshot 2026-08-21 at 11 09 30 AM" src="https://github.com/user-attachments/assets/1e3fd851-908f-4e0a-a534-d980ae13316a" />


<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🚀 Deployment Notes
<!-- Anything special about deploying this? (New env vars required?, etc) -->

LibGuides API version recently updated with new env vars -- see https://github.com/cul-it/blacklight-cornell/pull/2506. 

<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-969]: https://culibrary.atlassian.net/browse/DACCESS-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ