### PR TITLE
DACCESS-975 - Fix bootstrap 5 conflicts with pub year range facet

### DIFF
--- a/blacklight-cornell/app/assets/javascripts/advanced_search_validation.js
+++ b/blacklight-cornell/app/assets/javascripts/advanced_search_validation.js
@@ -7,7 +7,7 @@ const createAlertIconMarkup = () => `<svg class="advanced-search-alert__icon" vi
 
 // Group row (label + inputs)
 const findGroupRow = ($element) => {
-    const $group = $element.closest('.blacklight-date-range, fieldset, .range_limit, .form-group, .row');
+    const $group = $element.closest('.blacklight-date-range, fieldset, .range_limit, .adv-range, .row');
     return $group.length ? $group : $element.closest('form');
 };
 

--- a/blacklight-cornell/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/blacklight-cornell/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -7,6 +7,7 @@
     <div class="input-group-append visually-hidden">
       <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit], name: nil %>
     </div>
-    <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit] + " visually-hidden", "aria-hidden": "true", name: nil %>
+    <%# BEGIN CUSTOMIZATION: Remove sr-only tag that conflicts with fontawesome sr-only styling %>
+    <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit], "aria-hidden": "true", name: nil %>
   </div>
 <% end %>


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
Fixes bootstrap 5 conflicts with publication year conflict: Apply button is back and error messages in advanced search form display in the correct position again.

In the bootstrap 5 upgrade, I changed all instances of sr-only to visually-hidden, but blacklight_range_limit actually does want only sr-only here. But font-awesome gives sr-only styling that we don't want, so our local solution for now is just removing this class entirely. Hopefully, we can get rid of this whole view component html override when we upgrade blacklight_range_limit (as part of the sprockets-->propshaft migration).


<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-975](<https://culibrary.atlassian.net/browse/DACCESS-975>) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [ ] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This

BEFORE:
In search results:
1. Expand Publication Year facet panel
2. BUG: No Apply button!
3. Click "View larger" link to open modal
4. BUG: No Apply button!

In advanced search form (/edit or /advanced):
1. Enter a Publication Year start year, leave end year blank
2. BUG: error msg shows up higher than it should

Or:
1. Enter a Publication start year that is later than end year
2. BUG: error msg shows up higher than it should

AFTER:
In search results: Apply button should exist in Publication Year facet panel and expanded modal view
In advanced search form: Publication Year Range error messages show just above input fields and submit button


<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 📸 Screenshots
<!-- For UI changes, include before/after screenshots. -->
Before:

<img width="794" height="494" alt="Screenshot 2026-08-24 at 9 54 07 AM" src="https://github.com/user-attachments/assets/915a5860-38ff-4ce6-a1e5-1a728f537f31" />
<img width="428" height="351" alt="Screenshot 2026-08-24 at 9 53 31 AM" src="https://github.com/user-attachments/assets/c3341f11-5655-4a0a-8442-fe0df6a3952e" />
<img width="888" height="610" alt="Screenshot 2026-08-24 at 9 53 24 AM" src="https://github.com/user-attachments/assets/17c692a5-fd35-4134-9953-5d99931c9388" />


After:

<img width="413" height="379" alt="Screenshot 2026-08-24 at 10 40 19 AM" src="https://github.com/user-attachments/assets/56c002b7-e956-4a0d-b2b5-6643be5f1a01" />
<img width="879" height="625" alt="Screenshot 2026-08-24 at 10 40 14 AM" src="https://github.com/user-attachments/assets/58da81dd-97e4-4f2e-b2e4-e07187e8e208" />



<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed


[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-975]: https://culibrary.atlassian.net/browse/DACCESS-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ