### PR TITLE
DACCESS-978 - Fix broken emails by not setting query for q with ids

### DIFF
--- a/blacklight-cornell/app/models/search_builder.rb
+++ b/blacklight-cornell/app/models/search_builder.rb
@@ -78,7 +78,7 @@ class SearchBuilder < Blacklight::SearchBuilder
       solr_parameters[:search_field] = 'advanced'
 
       solr_parameters[:q] = build_advanced_search_query(blacklight_params)
-    elsif blacklight_params[:q].present? || blacklight_params[:search_field].present?
+    elsif blacklight_params[:search_field].present? || (blacklight_params[:q].present? && blacklight_params[:q].is_a?(String))
       # Remove any unexpected advanced search params
       if blacklight_params[:advanced_query].present?
         blacklight_params.delete(:advanced_query)

--- a/blacklight-cornell/spec/controllers/catalog_controller_spec.rb
+++ b/blacklight-cornell/spec/controllers/catalog_controller_spec.rb
@@ -220,6 +220,29 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
+  describe 'GET email' do
+    before do
+      session[:cu_authenticated_user] = true
+    end
+
+    context 'with a valid document id and no q or search_field params' do
+      it 'renders the email form instead of raising RecordNotFound' do
+        get :email, xhr: true, params: { id: '1001' }
+        expect(response).to be_successful
+        expect(assigns(:documents).map(&:id)).to eq(['1001'])
+      end
+    end
+
+    context 'without a session-authenticated user' do
+      it 'renders the cuwebauth prompt instead of the email form' do
+        session[:cu_authenticated_user] = nil
+        get :email, xhr: true, params: { id: '1001' }
+        expect(response).to be_successful
+        expect(response).to render_template(partial: 'catalog/_email_cuwebauth')
+      end
+    end
+  end
+
   describe "Ensure no duplicate saved searches to search history" do
     it "does not create a duplicate for equivalent BASIC search params" do
       params = { "q" => "cat", "search_field" => "all_fields" }

--- a/blacklight-cornell/spec/models/search_builder_spec.rb
+++ b/blacklight-cornell/spec/models/search_builder_spec.rb
@@ -1218,6 +1218,20 @@ RSpec.describe SearchBuilder, type: :model do
       end
     end
 
+    context 'id lookup with no search_field param (e.g. email/sms/citation actions)' do
+      # Blacklight::SearchBuilder#where (used by fetch_many for id-based lookups)
+      # stashes the id-filter conditions Hash into blacklight_params[:q]. set_query
+      # must leave solr_parameters[:q] alone in this case so the id-filter query
+      # built later by add_additional_filters isn't clobbered.
+      let(:blacklight_params) { { q: { 'id' => ['8638864'] } } }
+      let(:solr_params) { { q: '{!lucene}id:("8638864")' } }
+
+      it 'does not overwrite the existing solr q param' do
+        search_builder.set_query(solr_params)
+        expect(solr_params[:q]).to eq('{!lucene}id:("8638864")')
+      end
+    end
+
     context 'simple catalog search with search_field param' do
       let(:q) { 'test1 test2 test3'}
       let(:blacklight_params) { { q: q, search_field: search_field } }


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
Fix Email functionality for individual catalog records by not running solr q through the SearchBuilder's #set_query logic. Regression issue from recent change to default search_field='all_fields' when no search_field provided.



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-978](<https://culibrary.atlassian.net/browse/DACCESS-978>) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [ ] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
<!--
    Instructions so a reviewer can verify this PR locally.
    Include edge cases, test data, URLs, Staging or Integration environments used that may be helpful.
-->

In development, testing this is tricky because the real error is logged but swallowed in browser interactions. To test locally:

1. Comment out the condition in BlacklightCornell::CornellCatalog#record_not_found_error that renders if Rails.env == 'development':
```
  def record_not_found_error
    if false #Rails.env == 'development'
    ...
```
2. Restart your container
3. Go to any catalog record and click "Email"
4. Log in via netid if not already and click "Email" again
5. Make sure email form loads successfully in modal with no RecordNotFound error in logs


<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-978]: https://culibrary.atlassian.net/browse/DACCESS-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ