### PR TITLE
DACCESS-979 aspace item records have correct buttons

### DIFF
--- a/blacklight-cornell/app/views/catalog/_request_buttons.html.erb
+++ b/blacklight-cornell/app/views/catalog/_request_buttons.html.erb
@@ -15,6 +15,7 @@
   <% disabled_request_btn_opts = request_btn_opts.merge(:class => 'btn btn-danger disabled', :tabindex => '-1', :aria_disabled => 'true', :style => 'pointer-events: none;') %>
   <% scan_btn_opts = { :title => 'Request', :class => 'btn btn-outline-secondary', :id => 'id_request2' } %>
   <% pui_url = aspace_pui_url(@document) %>
+  <% show_archives_button = pui_url.present? && group == "Rare" %>
   <% illiad_url = ENV['ILLIAD_URL'] %>
 
   <div class="item-requests">
@@ -22,7 +23,7 @@
       <% if group == 'Rare' && ENV['DISABLE_AEON'] == 'true' %>
         <%= 'Reading Room delivery and scans of these materials are temporarily unavailable.' %>
       <% else %>
-        <% if @document["location"].present? && pui_url.nil? %>
+        <% if @document["location"].present? && !show_archives_button %>
           <% if reserve_only %>
             <%= link_to "Request item#{reading}", "#", disabled_request_btn_opts %>
           <% else %>
@@ -36,7 +37,7 @@
     <% end %>
 
     <%# show Archive button if the item is in Aspace %>
-    <% if pui_url.present? %>
+    <% if show_archives_button %>
       <%= link_to "Request from Archives at Cornell", pui_url, { :title => 'Request from Archives at Cornell', :class => 'btn btn-danger' } %>
     <% end %>
 


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
- Aspace items records that also have circulating holdings that can be requested
- added cucumber tests to check various request scenarios


<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
- [DACCESS-961](<https://culibrary.atlassian.net/browse/DACCESS-961>) 


<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [ ] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This
 
Check that an item in Aspace that has a circulating holding will show the Request item button. Example:
http://localhost:9292/catalog/5734587

<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 📸 Screenshots
<img width="1868" height="871" alt="image" src="https://github.com/user-attachments/assets/3b8b56a3-2035-4d3c-bf71-6b1f4aaf9c1d" />

<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-961]: https://culibrary.atlassian.net/browse/DACCESS-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ