### PR TITLE
DACCESS-968 - Upgrade blacklight-hierarchy to 6.9.0 with js override

### DIFF
--- a/blacklight-cornell/Gemfile
+++ b/blacklight-cornell/Gemfile
@@ -9,7 +9,7 @@ gem "appsignal", "~> 3.3.2" #, '2.11.10'
 gem "aws-sdk-s3", "~> 1.143"
 gem "bento_search", "~> 2.0.0.rc2"
 gem "blacklight", "< 9.0"
-gem "blacklight-hierarchy", "~> 6.5.0"
+gem "blacklight-hierarchy", "~> 6.9.0"
 gem "blacklight-marc", "~> 9.0"
 gem "blacklight_range_limit", "~> 8.5.0"
 gem "bootstrap", "~> 5.3"

--- a/blacklight-cornell/Gemfile.lock
+++ b/blacklight-cornell/Gemfile.lock
@@ -187,8 +187,8 @@ GEM
       rails (>= 6.1, < 9)
       view_component (>= 2.74, < 5)
       zeitwerk
-    blacklight-hierarchy (6.5.0)
-      blacklight (>= 7.18, < 9)
+    blacklight-hierarchy (6.9.0)
+      blacklight (>= 7.18, < 10)
       deprecation
       rails (>= 7.1, < 9)
     blacklight-marc (9.0.0)
@@ -865,7 +865,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.143)
   bento_search (~> 2.0.0.rc2)
   blacklight (< 9.0)
-  blacklight-hierarchy (~> 6.5.0)
+  blacklight-hierarchy (~> 6.9.0)
   blacklight-marc (~> 9.0)
   blacklight_cornell_requests!
   blacklight_range_limit (~> 8.5.0)

--- a/blacklight-cornell/app/assets/javascripts/application.js
+++ b/blacklight-cornell/app/assets/javascripts/application.js
@@ -26,7 +26,6 @@
 //= require 'blacklight_range_limit'
 
 
-//= require 'blacklight/hierarchy/hierarchy'
 //= require jquery-ui/widgets/autocomplete
 //= require print_button.js
 //

--- a/blacklight-cornell/app/assets/javascripts/blacklight/hierarchy/hierarchy.js
+++ b/blacklight-cornell/app/assets/javascripts/blacklight/hierarchy/hierarchy.js
@@ -1,0 +1,35 @@
+// blacklight-hierarchy removes jquery in v6.6.0, but this introduces an
+// Automatic Semicolon Insertion bug between the first and next lines.
+// Fixed by adding a semicolon to the end of the first line...
+// TODO: Remove this override when we migrate to propshaft and implement stimulus
+Blacklight.onLoad(() => Blacklight.do_hierarchical_facet_expand_contract_behavior());
+
+(() => {
+  Blacklight.do_hierarchical_facet_expand_contract_behavior = () => {
+    const elements = document.querySelectorAll(Blacklight.do_hierarchical_facet_expand_contract_behavior.selector)
+    elements.forEach(elem => Blacklight.hierarchical_facet_expand_contract(elem))
+  }
+  Blacklight.do_hierarchical_facet_expand_contract_behavior.selector = '[data-controller="b-h-collapsible"]'
+  Blacklight.do_hierarchical_facet_expand_contract_behavior.handle = '[data-action="click->b-h-collapsible#toggle"]'
+  Blacklight.do_hierarchical_facet_expand_contract_behavior.list = '[data-b-h-collapsible-target="list"]'
+
+  Blacklight.hierarchical_facet_expand_contract = (element) => {
+    element.classList.add('twiddle')
+
+    const lists = element.querySelectorAll(Blacklight.do_hierarchical_facet_expand_contract_behavior.list)
+
+    lists.forEach((list) => {
+      if (list.querySelector('span.selected')) {
+        element.classList.add('twiddle-open')
+        const collapseElement = element.querySelector('.collapse')
+        if (collapseElement) {
+          collapseElement.classList.add('show')
+        }
+      }
+    })
+
+    // attach the toggle behavior to the li tag
+    const handle = element.querySelector(Blacklight.do_hierarchical_facet_expand_contract_behavior.handle)
+    handle?.addEventListener('click', () => element.classList.toggle('twiddle-open'))
+  }
+})()

--- a/blacklight-cornell/app/assets/javascripts/blacklight_hierarchy.js
+++ b/blacklight-cornell/app/assets/javascripts/blacklight_hierarchy.js
@@ -1,0 +1,9 @@
+//= require blacklight/hierarchy/hierarchy
+
+// If you use Stimulus in your application you can remove the line above and require
+// blacklight_hierarchy_controller instead:
+//
+// import BlacklightHierarchyController from 'blacklight-hierarchy/app/assets/javascripts/blacklight/hierarchy/blacklight_hierarchy_controller'
+// import { Application } from '@hotwired/stimulus'
+// const application = Application.start()
+// application.register("b-h-collapsible", BlacklightHierarchyController)

--- a/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
+++ b/blacklight-cornell/app/assets/stylesheets/cornell/_facets.scss
@@ -17,23 +17,21 @@
 		margin-bottom: 0;
 		padding: 0;
 	}
-	a:hover { background: white; }
 }
-.facet-values {
+.facet-values, .h-leaf {
 	.facet-label {
 		text-indent: 0;
 		padding-left: 0;
 		word-break: normal;
 		i, svg {
 			margin-right: 3px;
-			height: 18px;
-  			width: 18px;
+			height: 19px;
+  			width: 19px;
 		}
 	}
 	.selected {
-		.facet-label {
-			padding-bottom: 0;
-		}
+		color: var(--bl-facet-active-item-color);
+		padding-bottom: 0;
 	}
 }
 .facets-heading {
@@ -58,12 +56,11 @@
 		padding-right: 0;
 	}
 	a.remove {
-		padding: 0;
 		display: inline-block;
 	}
 	a.remove:hover {
+      	color: $cornell-primary-hover;
 		text-decoration: none;
-		background: white;
 	}
 	a.remove:active, a.remove:focus {
 		border: 0;


### PR DESCRIPTION
<!-- ############################## ⚠️ REQUIRED ################################### -->
## 📝 Description
Upgrades blacklight-hierarchy from 6.5.0 to 6.9.0, which removes its jquery dependency and updates its styling for the "x" icon to match blacklight 8.
I'm very hackily overriding a bug with blacklight-hierarchy's sprockets-supported js, but we'll be able to get rid of the file I copied over from blacklight-hierarchy when we upgrade to propshaft and implement stimulus.



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-968](<https://culibrary.atlassian.net/browse/DACCESS-968>) 



<!-- ############################## ⚠️ REQUIRED ################################### -->
## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [x] 🐛 `bug` — Bug fix
- [x] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes



<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 🧑‍💻 How Reviewers Can Test This

Open Library Location or Call Number facet panels to see blacklight-hierarchy in action.

<!-- ################### ℹ️ Delete this section if not applicable ################# -->
## 📸 Screenshots
<!-- For UI changes, include before/after screenshots. -->
Before:

<img width="439" height="511" alt="image" src="https://github.com/user-attachments/assets/26e2c69b-f6bd-43a4-b148-4b1bccc5a06f" />


After:

<img width="417" height="530" alt="Screenshot 2026-08-25 at 1 31 52 PM" src="https://github.com/user-attachments/assets/dfeab930-1646-4f0a-9336-265e8a9a4b4b" />



<!-- ############################## ⚠️ REQUIRED ################################### -->
## ✅ Checklist
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-968]: https://culibrary.atlassian.net/browse/DACCESS-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ