### PR TITLE
DACCESS-984: improve spacing for print, clean-up, aeon print

### DIFF
--- a/blacklight-cornell/app/assets/stylesheets/aeon/_aeon_custom.scss
+++ b/blacklight-cornell/app/assets/stylesheets/aeon/_aeon_custom.scss
@@ -219,3 +219,23 @@ input[type="button"]#clear {
 {
     padding-left: 10px;
 }
+
+// Print styles
+
+@media print {
+
+	body {
+		font-family: -apple-system, BlinkMacSystemFont, “Segoe UI”, Roboto, Helvetica, Arial, sans-serif;
+		margin: 0;
+		color: #000;
+		background-color: #fff;
+		min-width: 0 !important;
+	}
+
+	.container, .container-fluid {
+		width: 100% !important;
+		max-width: 100% !important;
+		padding: 0 !important;
+		margin: 0 !important;
+	}
+}

--- a/blacklight-cornell/app/assets/stylesheets/print.scss
+++ b/blacklight-cornell/app/assets/stylesheets/print.scss
@@ -5,7 +5,16 @@
 		margin: 0;
 		color: #000;
 		background-color: #fff;
+		min-width: 0 !important;
 	}
+
+	.container, .container-fluid {
+		width: 100% !important;
+		max-width: 100% !important;
+		padding: 0 !important;
+		margin: 0 !important;
+	}
+
 
 	// Hide this stuff - TODO: some of these selectors may have been used in BL4, but not needed in BL5
 	.search-home {
@@ -33,22 +42,18 @@
 	.clear-bookmarks,
 	#startOverLink,
 	.search-widgets,
-	.paginate-section,
     .bookmarks-login,
 	.lcs_slide_out,
-	#syndetics_unbound, // TODO: does this actually hide syndetics?
+	#syndetics_unbound,
 	.databases-search,
 	.databases-az,
 	.digitalcollections-search .card,
 	.toplink,
 	.facet-pagination,
-	.navbar-toggler {
+	.navbar-toggler,
+	.other-resources {
 		display: none;
 	}
-
-	// TODO: want to hide these classes but it doesn't work; possibly because it is loaded via js after the print stylesheet is applied
-	// .call-number-browse
-	// .checkbox.select_all
 
 	// Hide dropdowns on Selected Items
 	.bookmarks {
@@ -62,24 +67,14 @@
 		a { text-decoration: none;}
 	}
 
-	// Don't print URLs
-	a[href]:after {
-	    content: ""
-	  }
-	abbr[title]:after {
-	    content: "";
-	  }
-
 	// hides covers on results
 	.document {
-		.iconcover, .bookcover { display: none; } 
+		.bookcover { display: none; } 
 	}
 
 	.blacklight-title_display {
 		margin: 1rem 0 0;
 	}
-
-	// .modal-header button { display: none; } // TODO: not needed?
 
 	// print  librarian view in monospace font
 	#marc_view { font-family: courier, monospace; }

--- a/blacklight-cornell/app/components/select_all_component.html.erb
+++ b/blacklight-cornell/app/components/select_all_component.html.erb
@@ -1,7 +1,7 @@
 
 <% if can_add_books %>
   <!-- credit to Princeton University Library -->
-  <div class="checkbox select_all btn btn-outline-secondary">
+  <div class="checkbox select_all btn btn-outline-secondary d-print-none">
     <label for="select_all_input">
       <input type="checkbox" id="select_all_input">
       <span>Select all</span>

--- a/blacklight-cornell/app/views/aeon/_aeon_header.html.erb
+++ b/blacklight-cornell/app/views/aeon/_aeon_header.html.erb
@@ -1,4 +1,6 @@
-<header class="head cornell-identity">
+
+<%= image_tag('cornell/layout/cul-logo-white.gif', class: 'd-none d-print-block') %>
+<header class="head cornell-identity d-print-none">
 	<div>
     	<a href="#main-content" onclick="$(\'#content\').focus();" class="offscreen">Skip to main content</a>
   	</div>

--- a/blacklight-cornell/app/views/aeon/reading_room_request.html.erb
+++ b/blacklight-cornell/app/views/aeon/reading_room_request.html.erb
@@ -19,7 +19,7 @@
 		<%= render :partial => 'aeon/aeon_header' %>
 		
 		<div id="main-content" class="container" aria-label="Main content" role="main">
-			<a href="/catalog/<%= @bibid %>" class="return-link">
+			<a href="/catalog/<%= @bibid %>" class="return-link d-print-none">
 				<i class="fa fa-arrow-circle-left"></i> Back to item
 			</a>
 			<h2>Reading Room Delivery Request</h2>

--- a/blacklight-cornell/app/views/browse/_virtual_browse.html.erb
+++ b/blacklight-cornell/app/views/browse/_virtual_browse.html.erb
@@ -50,7 +50,7 @@
 			<span class="visually-hidden">Scroll right</span>
 		</a>
 	</div>
-    <%= image_tag("cornell/virtual-browse/indicator1.gif", alt: "processing time indicator", id: "vb-time-indicator") %>
+    <%= image_tag("cornell/virtual-browse/indicator1.gif", alt: "processing time indicator", id: "vb-time-indicator", class: "d-print-none") %>
   </div>
 	  <div id="outer-container" class="slides-full" tabindex="0">
 		<div class="inner-container" id="prev-reroute" style="display:none;">

--- a/blacklight-cornell/app/views/shared/_header_navbar.html.erb
+++ b/blacklight-cornell/app/views/shared/_header_navbar.html.erb
@@ -1,12 +1,14 @@
 <%= render :partial=>'/shared/skip_to' %>
 <div class="cornell-identity" aria-label="Cornell" role="banner">
+  
   <div class="mobile-cornell-wrapper d-block d-sm-none">
     <div class="container">
       <a class="mobile-cornell-logo" href="http://www.cornell.edu">Cornell University</a>
     </div>
   </div>
   <div class="container">
-    <div class="cornell-brand">
+    <%= image_tag('cornell/layout/cul-logo-white.gif', class: 'd-none d-print-block') %>
+    <div class="cornell-brand d-print-none">
       <div class="row">
         <div class="cornell-logo col-9">
           <div class="logo d-none d-sm-block">

--- a/blacklight-cornell/app/views/single_search/index.html.erb
+++ b/blacklight-cornell/app/views/single_search/index.html.erb
@@ -23,7 +23,7 @@
     <div class="col-md-8 offset-md-2 empty-single-search">
       <div class="card card-well">
         <div class="card-body">
-          <div class="search-info">
+          <div class="search-info d-print-none">
             <%= tooltip("Search the Library Catalog, Articles and Full Text, and more. WorldCat is available through the Libraries Worldwide link in the search results.", link_name: "About this search", class_name: "float-end") %>
           </div>
           <h2>Search</h2>


### PR DESCRIPTION
## 📝 Description

Improvements for printing

- Remove excessive margins around content
- Add BS print utilities rather than style rules where possible
- Clean up TODOs
- Add print styles for Aeon margins and hide return link

## 🔗 Related Issues
<!-- Link any related issues (Example: [DACCESS-901](https://culibrary.atlassian.net/browse/DACCESS-901)) -->
- [DACCESS-984](<https://culibrary.atlassian.net/browse/DACCESS-984>) 

## 🔖 Type of Change
<!-- Add "X" to one or more boxes that apply. (At least one is required) -->

- [ ] 🚀 `feature` — New feature or enhancement
- [ ] 🐛 `bug` — Bug fix
- [X] 🧰 `maintenance` — Maintenance
- [ ] 🦮 `accessibility` — Accessibility updates
- [ ] 📚 `documentation` — Documentation changes

## 🧑‍💻 How Reviewers Can Test This

Go to any page in the catalog and print it. Example pages that a user might want to print?:

- Item record (e.g. 8638864)
- Search results (e.g. http://0.0.0.0:9292/?counter=1&document_id=17387285&f%5Bformat%5D%5B%5D=Manuscript%2FArchive&id=67&page=1&search_field=all_fields&total=21914)
- A list of databases (e.g. http://0.0.0.0:9292/databases/subject/Art%20and%20Architecture)

## ✅ Checklist
- [X] Tests added/updated (if needed)
- [X] Documentation updated (if needed)
- [X] No secrets, API keys, or credentials committed

[DACCESS-901]: https://culibrary.atlassian.net/browse/DACCESS-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DACCESS-984]: https://culibrary.atlassian.net/browse/DACCESS-984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ